### PR TITLE
fix: use 256-bit intermediate in pair mul_div()

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -181,6 +181,7 @@ name = "coralswap-pair"
 version = "0.1.0"
 dependencies = [
  "coralswap-flash-receiver-interface",
+ "ethnum",
  "soroban-sdk",
 ]
 

--- a/contracts/pair/Cargo.toml
+++ b/contracts/pair/Cargo.toml
@@ -10,6 +10,7 @@ doctest = false
 [dependencies]
 soroban-sdk = { workspace = true }
 coralswap-flash-receiver-interface = { path = "../flash_receiver_interface" }
+ethnum = { version = "*" }
 
 [dev-dependencies]
 soroban-sdk = { workspace = true, features = ["testutils"] }

--- a/contracts/pair/src/math/mod.rs
+++ b/contracts/pair/src/math/mod.rs
@@ -1,5 +1,6 @@
 //! Fixed-point arithmetic helpers for price and reserve calculations.
 //! All values use 1e14 scaling to maintain precision without floating point.
+use ethnum::U256;
 
 /// Fixed-point scale factor.
 #[allow(dead_code)]
@@ -16,9 +17,34 @@ pub fn mul_div(a: i128, b: i128, denominator: i128) -> Option<i128> {
     if denominator == 0 {
         return None;
     }
-    // Use u256 intermediate to avoid overflow on large reserves.
-    // TODO: implement with soroban U256 type
-    Some((a * b) / denominator)
+
+    let is_negative = (a < 0) ^ (b < 0) ^ (denominator < 0);
+    let a_abs = U256::from(a.unsigned_abs());
+    let b_abs = U256::from(b.unsigned_abs());
+    let denominator_abs = U256::from(denominator.unsigned_abs());
+
+    let quotient = a_abs.checked_mul(b_abs)?.checked_div(denominator_abs)?;
+
+    let max_positive = U256::from(i128::MAX as u128);
+    let max_negative_magnitude = U256::from(i128::MAX as u128) + U256::ONE;
+
+    if !is_negative {
+        if quotient > max_positive {
+            return None;
+        }
+        return i128::try_from(quotient.as_u128()).ok();
+    }
+
+    if quotient > max_negative_magnitude {
+        return None;
+    }
+
+    if quotient == max_negative_magnitude {
+        return Some(i128::MIN);
+    }
+
+    let magnitude = i128::try_from(quotient.as_u128()).ok()?;
+    Some(-magnitude)
 }
 
 /// Computed integer square root using Newton's method.

--- a/contracts/pair/src/test/swap_math.rs
+++ b/contracts/pair/src/test/swap_math.rs
@@ -292,7 +292,22 @@ mod swap_math_tests {
         assert_eq!(result, None, "mul_div with zero denominator must return None");
     }
 
-    // ---- 14. sqrt: known values ----
+    // ---- 14. mul_div: large inputs near i128::MAX / 2 do not overflow ----
+    #[test]
+    fn test_mul_div_large_values_near_i128_max_half() {
+        let _env = Env::default();
+
+        let half_max = i128::MAX / 2;
+        let result = mul_div(half_max, half_max, half_max);
+
+        assert_eq!(
+            result,
+            Some(half_max),
+            "mul_div should use a wide intermediate and avoid overflow near i128 limits"
+        );
+    }
+
+    // ---- 15. sqrt: known values ----
     #[test]
     fn test_sqrt_known_values() {
         let _env = Env::default();
@@ -311,7 +326,7 @@ mod swap_math_tests {
         assert_eq!(sqrt(10), 3);
     }
 
-    // ---- 15. sqrt: negative input returns zero ----
+    // ---- 16. sqrt: negative input returns zero ----
     #[test]
     fn test_sqrt_negative_returns_zero() {
         let _env = Env::default();
@@ -321,7 +336,7 @@ mod swap_math_tests {
         assert_eq!(sqrt(i128::MIN), 0);
     }
 
-    // ---- 16. Symmetry: swapping direction gives equivalent results ----
+    // ---- 17. Symmetry: swapping direction gives equivalent results ----
     #[test]
     fn test_swap_symmetry_balanced_pool() {
         let _env = Env::default();
@@ -338,7 +353,7 @@ mod swap_math_tests {
         assert_eq!(out_a_to_b, out_b_to_a, "balanced pool must produce symmetric outputs");
     }
 
-    // ---- 17. Large realistic swap: price impact sanity ----
+    // ---- 18. Large realistic swap: price impact sanity ----
     #[test]
     fn test_large_swap_price_impact() {
         let _env = Env::default();
@@ -362,7 +377,7 @@ mod swap_math_tests {
         assert!(amount_out > 0, "amount_out must be positive");
     }
 
-    // ---- 18. Tiny swap: dust amount still produces valid output ----
+    // ---- 19. Tiny swap: dust amount still produces valid output ----
     #[test]
     fn test_tiny_swap_dust_amount() {
         let _env = Env::default();


### PR DESCRIPTION
## Summary
- replace `mul_div()`'s direct `i128` multiplication with `ethnum::U256` intermediate arithmetic
- handle sign and i128 bounds explicitly so out-of-range results return `None`
- add a regression test using values near `i128::MAX / 2` to ensure no pre-division overflow
- remove the stale TODO that deferred this overflow fix

## Test plan
- [x] `cargo check -p coralswap-pair --lib`
- [ ] Run full `cargo test` suite (currently blocked by existing repository-wide test harness/build issues unrelated to this patch)

Closes #73

Made with [Cursor](https://cursor.com)