### PR TITLE
fix(lp-token): return typed errors for metadata reads

### DIFF
--- a/contracts/lp_token/Cargo.toml
+++ b/contracts/lp_token/Cargo.toml
@@ -11,7 +11,4 @@ doctest = false
 soroban-sdk = { workspace = true }
 
 [dev-dependencies]
-# Note: testutils feature disabled due to known issue with soroban-sdk 21.7.6
-# The contract compiles successfully and follows SEP-41 standard
-# Integration tests can be performed using soroban CLI
-soroban-sdk = { workspace = true }
+soroban-sdk = { workspace = true, features = ["testutils"] }

--- a/contracts/lp_token/src/lib.rs
+++ b/contracts/lp_token/src/lib.rs
@@ -206,24 +206,33 @@ impl LpToken {
     }
 
     /// Get the number of decimals
-    pub fn decimals(env: Env) -> u32 {
-        let metadata: TokenMetadata =
-            env.storage().instance().get(&LpTokenKey::Metadata).expect("Token not initialized");
-        metadata.decimals
+    pub fn decimals(env: Env) -> Result<u32, LpTokenError> {
+        let metadata: TokenMetadata = env
+            .storage()
+            .instance()
+            .get(&LpTokenKey::Metadata)
+            .ok_or(LpTokenError::NotInitialized)?;
+        Ok(metadata.decimals)
     }
 
     /// Get the token name
-    pub fn name(env: Env) -> String {
-        let metadata: TokenMetadata =
-            env.storage().instance().get(&LpTokenKey::Metadata).expect("Token not initialized");
-        metadata.name
+    pub fn name(env: Env) -> Result<String, LpTokenError> {
+        let metadata: TokenMetadata = env
+            .storage()
+            .instance()
+            .get(&LpTokenKey::Metadata)
+            .ok_or(LpTokenError::NotInitialized)?;
+        Ok(metadata.name)
     }
 
     /// Get the token symbol
-    pub fn symbol(env: Env) -> String {
-        let metadata: TokenMetadata =
-            env.storage().instance().get(&LpTokenKey::Metadata).expect("Token not initialized");
-        metadata.symbol
+    pub fn symbol(env: Env) -> Result<String, LpTokenError> {
+        let metadata: TokenMetadata = env
+            .storage()
+            .instance()
+            .get(&LpTokenKey::Metadata)
+            .ok_or(LpTokenError::NotInitialized)?;
+        Ok(metadata.symbol)
     }
 
     /// Get the total supply

--- a/contracts/lp_token/src/test/mod.rs
+++ b/contracts/lp_token/src/test/mod.rs
@@ -1,18 +1,53 @@
-// Note: Due to a known issue with soroban-sdk 21.7.6 testutils and the arbitrary feature,
-// comprehensive unit tests are temporarily disabled. The contract implementation follows
-// the SEP-41 token standard and has been verified to compile successfully.
-//
-// The contract implements all required functions:
-// - initialize(): Stores metadata and prevents re-initialization
-// - mint(): Only callable by admin (pair contract)
-// - burn(): Requires authorization from token holder
-// - transfer(): Requires authorization from sender
-// - transfer_from(): Deducts allowance correctly
-// - approve(): Sets allowance with expiration ledger TTL
-// - balance(): Returns correct amounts after mint/transfer/burn
-// - allowance(): Returns allowance with expiration checking
-// - total_supply(): Tracks mints and burns accurately
-// - decimals(), name(), symbol(): Return token metadata
-//
-// Integration tests can be performed using the soroban CLI or in the context
-// of the full DEX system where this LP token will be used by pair contracts.
+use crate::errors::LpTokenError;
+use crate::{LpToken, LpTokenClient};
+use soroban_sdk::{testutils::Address as _, Address, Env, String};
+
+fn setup_env() -> (Env, Address, LpTokenClient<'static>, Address) {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let contract_id = env.register_contract(None, LpToken);
+    let client = LpTokenClient::new(&env, &contract_id);
+    let admin = Address::generate(&env);
+
+    (env, contract_id, client, admin)
+}
+
+fn initialize_client(client: &LpTokenClient<'_>, env: &Env, admin: &Address) {
+    client.initialize(admin, &7, &String::from_str(env, "Coral LP"), &String::from_str(env, "CLP"));
+}
+
+#[test]
+fn decimals_returns_not_initialized_when_metadata_missing() {
+    let (_env, _contract_id, client, _admin) = setup_env();
+
+    let result = client.try_decimals();
+    assert_eq!(result, Err(Ok(LpTokenError::NotInitialized)));
+}
+
+#[test]
+fn name_returns_not_initialized_when_metadata_missing() {
+    let (_env, _contract_id, client, _admin) = setup_env();
+
+    let result = client.try_name();
+    assert_eq!(result, Err(Ok(LpTokenError::NotInitialized)));
+}
+
+#[test]
+fn symbol_returns_not_initialized_when_metadata_missing() {
+    let (_env, _contract_id, client, _admin) = setup_env();
+
+    let result = client.try_symbol();
+    assert_eq!(result, Err(Ok(LpTokenError::NotInitialized)));
+}
+
+#[test]
+fn metadata_reads_return_stored_values_after_initialize() {
+    let (env, _contract_id, client, admin) = setup_env();
+
+    initialize_client(&client, &env, &admin);
+
+    assert_eq!(client.decimals(), 7);
+    assert_eq!(client.name(), String::from_str(&env, "Coral LP"));
+    assert_eq!(client.symbol(), String::from_str(&env, "CLP"));
+}


### PR DESCRIPTION
Closes #77

---

This PR fixes unsafe metadata reads in the LP token contract by returning typed errors instead of panicking when metadata is unavailable.

In contracts/lp_token/src/lib.rs, the decimals(), name(), and symbol() functions now return Result<_, LpTokenError> and map missing metadata to LpTokenError::NotInitialized rather than using .expect(...).