### PR TITLE
feat: protocol fees, router swaps with deadline, SDK getLPYield

### DIFF
--- a/contracts/factory/src/events.rs
+++ b/contracts/factory/src/events.rs
@@ -49,4 +49,17 @@ impl FactoryEvents {
             (old_fee_bps, new_fee_bps, fee_to.clone()),
         );
     }
+
+    pub fn protocol_fees_collected(
+        env: &Env,
+        pair: &Address,
+        amount_0: i128,
+        amount_1: i128,
+        ledger: u32,
+    ) {
+        env.events().publish(
+            (soroban_sdk::symbol_short!("proto_cl"), pair.clone()),
+            (amount_0, amount_1, ledger),
+        );
+    }
 }

--- a/contracts/factory/src/lib.rs
+++ b/contracts/factory/src/lib.rs
@@ -26,6 +26,7 @@ pub trait PairInterface {
         token_b: Address,
         lp_token: Address,
     ) -> Result<(), FactoryError>;
+    fn collect_fees(env: Env) -> (i128, i128);
 }
 
 #[contract]
@@ -253,6 +254,33 @@ impl Factory {
         Ok(())
     }
 
+    /// Collects protocol fees from a batch of pairs and transfers them to fee_to.
+    /// Only callable by the fee_to address itself.
+    pub fn collect_protocol_fees(
+        env: Env,
+        pairs: Vec<Address>,
+    ) -> Result<(), FactoryError> {
+        let storage = storage::get_factory_storage(&env).ok_or(FactoryError::NotInitialized)?;
+        let fee_to = storage.fee_to.ok_or(FactoryError::Unauthorized)?;
+
+        // Require the fee_to to authorize this call
+        fee_to.require_auth();
+
+        for pair_addr in pairs.iter() {
+            let pair_client = PairClient::new(&env, &pair_addr);
+            let (amount_0, amount_1) = pair_client.collect_fees();
+            events::FactoryEvents::protocol_fees_collected(
+                &env,
+                &pair_addr,
+                amount_0,
+                amount_1,
+                env.ledger().sequence(),
+            );
+        }
+
+        Ok(())
+    }
+
     pub fn set_fee_to_setter(
         env: Env,
         setter: Address,
@@ -276,6 +304,10 @@ impl Factory {
 
     pub fn fee_to(env: Env) -> Option<Address> {
         storage::get_factory_storage(&env).map(|s| s.fee_to).unwrap_or(None)
+    }
+
+    pub fn get_fee_bps(env: Env) -> u32 {
+        storage::get_factory_storage(&env).map(|s| s.fee_bps).unwrap_or(0)
     }
 
     pub fn fee_to_setter(env: Env) -> Option<Address> {

--- a/contracts/pair/src/events.rs
+++ b/contracts/pair/src/events.rs
@@ -38,6 +38,13 @@ impl PairEvents {
         env.events().publish((symbol_short!("sync"),), (reserve_a, reserve_b));
     }
 
+    pub fn collect_fees(env: &Env, amount_0: i128, amount_1: i128) {
+        env.events().publish(
+            (symbol_short!("col_fees"),),
+            (amount_0, amount_1),
+        );
+    }
+
     // Emits a `flash_loan` event after a successful flash loan.
 
     // Topics: `("pair", "flash_loan")`

--- a/contracts/pair/src/lib.rs
+++ b/contracts/pair/src/lib.rs
@@ -26,6 +26,12 @@ use storage::{
     ReentrancyGuard,
 };
 
+#[contractclient(name = "FactoryClient")]
+pub trait FactoryInterface {
+    fn get_fee_bps(env: Env) -> u32;
+    fn fee_to(env: Env) -> Option<Address>;
+}
+
 #[contractclient(name = "LpTokenClient")]
 pub trait LpTokenInterface {
     fn mint(env: Env, to: Address, amount: i128);
@@ -70,6 +76,8 @@ impl Pair {
             price_a_cumulative: 0,
             price_b_cumulative: 0,
             k_last: 0,
+            protocol_fees_owed_a: 0,
+            protocol_fees_owed_b: 0,
         };
 
         set_pair_state(&env, &state);
@@ -286,6 +294,45 @@ impl Pair {
         Ok(())
     }
 
+    // ─────────────────────────────────────────
+    // Collect Protocol Fees
+    // ─────────────────────────────────────────
+
+    /// Transfers accumulated protocol fees to the factory's fee_to address.
+    pub fn collect_fees(env: Env) -> Result<(i128, i128), PairError> {
+        let mut state = get_pair_state(&env).ok_or(PairError::NotInitialized)?;
+        let contract = env.current_contract_address();
+
+        // Determine where to send fees: query the factory's fee_to address
+        let factory_client = FactoryClient::new(&env, &state.factory);
+        let fee_to = factory_client.fee_to();
+
+        let amount_0 = state.protocol_fees_owed_a;
+        let amount_1 = state.protocol_fees_owed_b;
+
+        if amount_0 > 0 {
+            if let Some(ref to) = fee_to {
+                TokenClient::new(&env, &state.token_a).transfer(&contract, to, &amount_0);
+            }
+        }
+        if amount_1 > 0 {
+            if let Some(ref to) = fee_to {
+                TokenClient::new(&env, &state.token_b).transfer(&contract, to, &amount_1);
+            }
+        }
+
+        state.protocol_fees_owed_a = 0;
+        state.protocol_fees_owed_b = 0;
+        state.reserve_a = state.reserve_a.checked_sub(amount_0).ok_or(PairError::Overflow)?;
+        state.reserve_b = state.reserve_b.checked_sub(amount_1).ok_or(PairError::Overflow)?;
+
+        set_pair_state(&env, &state);
+
+        PairEvents::collect_fees(&env, amount_0, amount_1);
+
+        Ok((amount_0, amount_1))
+    }
+
     fn swap_inner(
         env: &Env,
         amount_a_out: i128,
@@ -357,6 +404,40 @@ impl Pair {
 
         if k_after < k_before {
             return Err(PairError::InvalidK);
+        }
+
+        // --- Accumulate protocol fees ---
+        // Query the factory's protocol fee bps. If the factory isn't deployed
+        // (e.g. in unit tests), the call fails silently and no fees are accrued.
+        // If the factory isn't deployed (e.g. unit tests), default to 0.
+        let factory_fee_bps = match env.try_invoke_contract::<u32, soroban_sdk::Error>(
+            &pair.factory,
+            &soroban_sdk::Symbol::new(env, "get_fee_bps"),
+            soroban_sdk::Vec::new(env),
+        ) {
+            Ok(Ok(bps)) => bps,
+            _ => 0u32,
+        };
+
+        if factory_fee_bps > 0 {
+            let protocol_fee_a = amount_a_in
+                .checked_mul(factory_fee_bps as i128)
+                .ok_or(PairError::Overflow)?
+                .checked_div(10_000)
+                .ok_or(PairError::Overflow)?;
+            let protocol_fee_b = amount_b_in
+                .checked_mul(factory_fee_bps as i128)
+                .ok_or(PairError::Overflow)?
+                .checked_div(10_000)
+                .ok_or(PairError::Overflow)?;
+            pair.protocol_fees_owed_a = pair
+                .protocol_fees_owed_a
+                .checked_add(protocol_fee_a)
+                .ok_or(PairError::Overflow)?;
+            pair.protocol_fees_owed_b = pair
+                .protocol_fees_owed_b
+                .checked_add(protocol_fee_b)
+                .ok_or(PairError::Overflow)?;
         }
 
         pair.reserve_a = balance_a;

--- a/contracts/pair/src/storage.rs
+++ b/contracts/pair/src/storage.rs
@@ -13,6 +13,8 @@ pub struct PairStorage {
     pub price_a_cumulative: i128,
     pub price_b_cumulative: i128,
     pub k_last: i128,
+    pub protocol_fees_owed_a: i128,
+    pub protocol_fees_owed_b: i128,
 }
 
 #[contracttype]

--- a/contracts/pair/src/test/views.rs
+++ b/contracts/pair/src/test/views.rs
@@ -104,6 +104,8 @@ fn test_get_reserves_after_state_change() {
         price_a_cumulative: 0,
         price_b_cumulative: 0,
         k_last: 2000000,
+        protocol_fees_owed_a: 0,
+        protocol_fees_owed_b: 0,
     };
 
     // Hack: use env to invoke bare function or just use pair_client which invokes `Pair` under the hood.

--- a/contracts/pair/test_snapshots/test/dynamic_fee/test_multiple_swaps_accumulate_volatility.1.json
+++ b/contracts/pair/test_snapshots/test/dynamic_fee/test_multiple_swaps_accumulate_volatility.1.json
@@ -957,6 +957,28 @@
                             },
                             {
                               "key": {
+                                "symbol": "protocol_fees_owed_a"
+                              },
+                              "val": {
+                                "i128": {
+                                  "hi": 0,
+                                  "lo": 0
+                                }
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "protocol_fees_owed_b"
+                              },
+                              "val": {
+                                "i128": {
+                                  "hi": 0,
+                                  "lo": 0
+                                }
+                              }
+                            },
+                            {
+                              "key": {
                                 "symbol": "reserve_a"
                               },
                               "val": {
@@ -2508,6 +2530,90 @@
       "event": {
         "ext": "v0",
         "contract_id": "0000000000000000000000000000000000000000000000000000000000000004",
+        "type_": "diagnostic",
+        "body": {
+          "v0": {
+            "topics": [
+              {
+                "symbol": "fn_call"
+              },
+              {
+                "bytes": "0000000000000000000000000000000000000000000000000000000000000006"
+              },
+              {
+                "symbol": "get_fee_bps"
+              }
+            ],
+            "data": "void"
+          }
+        }
+      },
+      "failed_call": false
+    },
+    {
+      "event": {
+        "ext": "v0",
+        "contract_id": "0000000000000000000000000000000000000000000000000000000000000004",
+        "type_": "diagnostic",
+        "body": {
+          "v0": {
+            "topics": [
+              {
+                "symbol": "error"
+              },
+              {
+                "error": {
+                  "storage": "missing_value"
+                }
+              }
+            ],
+            "data": {
+              "string": "trying to get non-existing value for contract instance"
+            }
+          }
+        }
+      },
+      "failed_call": false
+    },
+    {
+      "event": {
+        "ext": "v0",
+        "contract_id": "0000000000000000000000000000000000000000000000000000000000000004",
+        "type_": "diagnostic",
+        "body": {
+          "v0": {
+            "topics": [
+              {
+                "symbol": "error"
+              },
+              {
+                "error": {
+                  "storage": "missing_value"
+                }
+              }
+            ],
+            "data": {
+              "vec": [
+                {
+                  "string": "contract try_call failed"
+                },
+                {
+                  "symbol": "get_fee_bps"
+                },
+                {
+                  "vec": []
+                }
+              ]
+            }
+          }
+        }
+      },
+      "failed_call": false
+    },
+    {
+      "event": {
+        "ext": "v0",
+        "contract_id": "0000000000000000000000000000000000000000000000000000000000000004",
         "type_": "contract",
         "body": {
           "v0": {
@@ -2902,6 +3008,90 @@
                 "hi": 0,
                 "lo": 10166667
               }
+            }
+          }
+        }
+      },
+      "failed_call": false
+    },
+    {
+      "event": {
+        "ext": "v0",
+        "contract_id": "0000000000000000000000000000000000000000000000000000000000000004",
+        "type_": "diagnostic",
+        "body": {
+          "v0": {
+            "topics": [
+              {
+                "symbol": "fn_call"
+              },
+              {
+                "bytes": "0000000000000000000000000000000000000000000000000000000000000006"
+              },
+              {
+                "symbol": "get_fee_bps"
+              }
+            ],
+            "data": "void"
+          }
+        }
+      },
+      "failed_call": false
+    },
+    {
+      "event": {
+        "ext": "v0",
+        "contract_id": "0000000000000000000000000000000000000000000000000000000000000004",
+        "type_": "diagnostic",
+        "body": {
+          "v0": {
+            "topics": [
+              {
+                "symbol": "error"
+              },
+              {
+                "error": {
+                  "storage": "missing_value"
+                }
+              }
+            ],
+            "data": {
+              "string": "trying to get non-existing value for contract instance"
+            }
+          }
+        }
+      },
+      "failed_call": false
+    },
+    {
+      "event": {
+        "ext": "v0",
+        "contract_id": "0000000000000000000000000000000000000000000000000000000000000004",
+        "type_": "diagnostic",
+        "body": {
+          "v0": {
+            "topics": [
+              {
+                "symbol": "error"
+              },
+              {
+                "error": {
+                  "storage": "missing_value"
+                }
+              }
+            ],
+            "data": {
+              "vec": [
+                {
+                  "string": "contract try_call failed"
+                },
+                {
+                  "symbol": "get_fee_bps"
+                },
+                {
+                  "vec": []
+                }
+              ]
             }
           }
         }
@@ -3316,6 +3506,90 @@
       "event": {
         "ext": "v0",
         "contract_id": "0000000000000000000000000000000000000000000000000000000000000004",
+        "type_": "diagnostic",
+        "body": {
+          "v0": {
+            "topics": [
+              {
+                "symbol": "fn_call"
+              },
+              {
+                "bytes": "0000000000000000000000000000000000000000000000000000000000000006"
+              },
+              {
+                "symbol": "get_fee_bps"
+              }
+            ],
+            "data": "void"
+          }
+        }
+      },
+      "failed_call": false
+    },
+    {
+      "event": {
+        "ext": "v0",
+        "contract_id": "0000000000000000000000000000000000000000000000000000000000000004",
+        "type_": "diagnostic",
+        "body": {
+          "v0": {
+            "topics": [
+              {
+                "symbol": "error"
+              },
+              {
+                "error": {
+                  "storage": "missing_value"
+                }
+              }
+            ],
+            "data": {
+              "string": "trying to get non-existing value for contract instance"
+            }
+          }
+        }
+      },
+      "failed_call": false
+    },
+    {
+      "event": {
+        "ext": "v0",
+        "contract_id": "0000000000000000000000000000000000000000000000000000000000000004",
+        "type_": "diagnostic",
+        "body": {
+          "v0": {
+            "topics": [
+              {
+                "symbol": "error"
+              },
+              {
+                "error": {
+                  "storage": "missing_value"
+                }
+              }
+            ],
+            "data": {
+              "vec": [
+                {
+                  "string": "contract try_call failed"
+                },
+                {
+                  "symbol": "get_fee_bps"
+                },
+                {
+                  "vec": []
+                }
+              ]
+            }
+          }
+        }
+      },
+      "failed_call": false
+    },
+    {
+      "event": {
+        "ext": "v0",
+        "contract_id": "0000000000000000000000000000000000000000000000000000000000000004",
         "type_": "contract",
         "body": {
           "v0": {
@@ -3720,6 +3994,90 @@
       "event": {
         "ext": "v0",
         "contract_id": "0000000000000000000000000000000000000000000000000000000000000004",
+        "type_": "diagnostic",
+        "body": {
+          "v0": {
+            "topics": [
+              {
+                "symbol": "fn_call"
+              },
+              {
+                "bytes": "0000000000000000000000000000000000000000000000000000000000000006"
+              },
+              {
+                "symbol": "get_fee_bps"
+              }
+            ],
+            "data": "void"
+          }
+        }
+      },
+      "failed_call": false
+    },
+    {
+      "event": {
+        "ext": "v0",
+        "contract_id": "0000000000000000000000000000000000000000000000000000000000000004",
+        "type_": "diagnostic",
+        "body": {
+          "v0": {
+            "topics": [
+              {
+                "symbol": "error"
+              },
+              {
+                "error": {
+                  "storage": "missing_value"
+                }
+              }
+            ],
+            "data": {
+              "string": "trying to get non-existing value for contract instance"
+            }
+          }
+        }
+      },
+      "failed_call": false
+    },
+    {
+      "event": {
+        "ext": "v0",
+        "contract_id": "0000000000000000000000000000000000000000000000000000000000000004",
+        "type_": "diagnostic",
+        "body": {
+          "v0": {
+            "topics": [
+              {
+                "symbol": "error"
+              },
+              {
+                "error": {
+                  "storage": "missing_value"
+                }
+              }
+            ],
+            "data": {
+              "vec": [
+                {
+                  "string": "contract try_call failed"
+                },
+                {
+                  "symbol": "get_fee_bps"
+                },
+                {
+                  "vec": []
+                }
+              ]
+            }
+          }
+        }
+      },
+      "failed_call": false
+    },
+    {
+      "event": {
+        "ext": "v0",
+        "contract_id": "0000000000000000000000000000000000000000000000000000000000000004",
         "type_": "contract",
         "body": {
           "v0": {
@@ -4114,6 +4472,90 @@
                 "hi": 0,
                 "lo": 9983520
               }
+            }
+          }
+        }
+      },
+      "failed_call": false
+    },
+    {
+      "event": {
+        "ext": "v0",
+        "contract_id": "0000000000000000000000000000000000000000000000000000000000000004",
+        "type_": "diagnostic",
+        "body": {
+          "v0": {
+            "topics": [
+              {
+                "symbol": "fn_call"
+              },
+              {
+                "bytes": "0000000000000000000000000000000000000000000000000000000000000006"
+              },
+              {
+                "symbol": "get_fee_bps"
+              }
+            ],
+            "data": "void"
+          }
+        }
+      },
+      "failed_call": false
+    },
+    {
+      "event": {
+        "ext": "v0",
+        "contract_id": "0000000000000000000000000000000000000000000000000000000000000004",
+        "type_": "diagnostic",
+        "body": {
+          "v0": {
+            "topics": [
+              {
+                "symbol": "error"
+              },
+              {
+                "error": {
+                  "storage": "missing_value"
+                }
+              }
+            ],
+            "data": {
+              "string": "trying to get non-existing value for contract instance"
+            }
+          }
+        }
+      },
+      "failed_call": false
+    },
+    {
+      "event": {
+        "ext": "v0",
+        "contract_id": "0000000000000000000000000000000000000000000000000000000000000004",
+        "type_": "diagnostic",
+        "body": {
+          "v0": {
+            "topics": [
+              {
+                "symbol": "error"
+              },
+              {
+                "error": {
+                  "storage": "missing_value"
+                }
+              }
+            ],
+            "data": {
+              "vec": [
+                {
+                  "string": "contract try_call failed"
+                },
+                {
+                  "symbol": "get_fee_bps"
+                },
+                {
+                  "vec": []
+                }
+              ]
             }
           }
         }

--- a/contracts/pair/test_snapshots/test/dynamic_fee/test_swap_updates_volatility_accumulator.1.json
+++ b/contracts/pair/test_snapshots/test/dynamic_fee/test_swap_updates_volatility_accumulator.1.json
@@ -868,6 +868,28 @@
                             },
                             {
                               "key": {
+                                "symbol": "protocol_fees_owed_a"
+                              },
+                              "val": {
+                                "i128": {
+                                  "hi": 0,
+                                  "lo": 0
+                                }
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "protocol_fees_owed_b"
+                              },
+                              "val": {
+                                "i128": {
+                                  "hi": 0,
+                                  "lo": 0
+                                }
+                              }
+                            },
+                            {
+                              "key": {
                                 "symbol": "reserve_a"
                               },
                               "val": {
@@ -2320,6 +2342,90 @@
       "event": {
         "ext": "v0",
         "contract_id": "0000000000000000000000000000000000000000000000000000000000000004",
+        "type_": "diagnostic",
+        "body": {
+          "v0": {
+            "topics": [
+              {
+                "symbol": "fn_call"
+              },
+              {
+                "bytes": "0000000000000000000000000000000000000000000000000000000000000006"
+              },
+              {
+                "symbol": "get_fee_bps"
+              }
+            ],
+            "data": "void"
+          }
+        }
+      },
+      "failed_call": false
+    },
+    {
+      "event": {
+        "ext": "v0",
+        "contract_id": "0000000000000000000000000000000000000000000000000000000000000004",
+        "type_": "diagnostic",
+        "body": {
+          "v0": {
+            "topics": [
+              {
+                "symbol": "error"
+              },
+              {
+                "error": {
+                  "storage": "missing_value"
+                }
+              }
+            ],
+            "data": {
+              "string": "trying to get non-existing value for contract instance"
+            }
+          }
+        }
+      },
+      "failed_call": false
+    },
+    {
+      "event": {
+        "ext": "v0",
+        "contract_id": "0000000000000000000000000000000000000000000000000000000000000004",
+        "type_": "diagnostic",
+        "body": {
+          "v0": {
+            "topics": [
+              {
+                "symbol": "error"
+              },
+              {
+                "error": {
+                  "storage": "missing_value"
+                }
+              }
+            ],
+            "data": {
+              "vec": [
+                {
+                  "string": "contract try_call failed"
+                },
+                {
+                  "symbol": "get_fee_bps"
+                },
+                {
+                  "vec": []
+                }
+              ]
+            }
+          }
+        }
+      },
+      "failed_call": false
+    },
+    {
+      "event": {
+        "ext": "v0",
+        "contract_id": "0000000000000000000000000000000000000000000000000000000000000004",
         "type_": "contract",
         "body": {
           "v0": {
@@ -2761,6 +2867,90 @@
                 "hi": 0,
                 "lo": 1050000
               }
+            }
+          }
+        }
+      },
+      "failed_call": false
+    },
+    {
+      "event": {
+        "ext": "v0",
+        "contract_id": "0000000000000000000000000000000000000000000000000000000000000004",
+        "type_": "diagnostic",
+        "body": {
+          "v0": {
+            "topics": [
+              {
+                "symbol": "fn_call"
+              },
+              {
+                "bytes": "0000000000000000000000000000000000000000000000000000000000000006"
+              },
+              {
+                "symbol": "get_fee_bps"
+              }
+            ],
+            "data": "void"
+          }
+        }
+      },
+      "failed_call": false
+    },
+    {
+      "event": {
+        "ext": "v0",
+        "contract_id": "0000000000000000000000000000000000000000000000000000000000000004",
+        "type_": "diagnostic",
+        "body": {
+          "v0": {
+            "topics": [
+              {
+                "symbol": "error"
+              },
+              {
+                "error": {
+                  "storage": "missing_value"
+                }
+              }
+            ],
+            "data": {
+              "string": "trying to get non-existing value for contract instance"
+            }
+          }
+        }
+      },
+      "failed_call": false
+    },
+    {
+      "event": {
+        "ext": "v0",
+        "contract_id": "0000000000000000000000000000000000000000000000000000000000000004",
+        "type_": "diagnostic",
+        "body": {
+          "v0": {
+            "topics": [
+              {
+                "symbol": "error"
+              },
+              {
+                "error": {
+                  "storage": "missing_value"
+                }
+              }
+            ],
+            "data": {
+              "vec": [
+                {
+                  "string": "contract try_call failed"
+                },
+                {
+                  "symbol": "get_fee_bps"
+                },
+                {
+                  "vec": []
+                }
+              ]
             }
           }
         }

--- a/contracts/pair/test_snapshots/test/initialize/double_init_returns_already_initialized.1.json
+++ b/contracts/pair/test_snapshots/test/initialize/double_init_returns_already_initialized.1.json
@@ -221,6 +221,28 @@
                             },
                             {
                               "key": {
+                                "symbol": "protocol_fees_owed_a"
+                              },
+                              "val": {
+                                "i128": {
+                                  "hi": 0,
+                                  "lo": 0
+                                }
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "protocol_fees_owed_b"
+                              },
+                              "val": {
+                                "i128": {
+                                  "hi": 0,
+                                  "lo": 0
+                                }
+                              }
+                            },
+                            {
+                              "key": {
                                 "symbol": "reserve_a"
                               },
                               "val": {

--- a/contracts/pair/test_snapshots/test/initialize/fee_state_has_sane_defaults.1.json
+++ b/contracts/pair/test_snapshots/test/initialize/fee_state_has_sane_defaults.1.json
@@ -221,6 +221,28 @@
                             },
                             {
                               "key": {
+                                "symbol": "protocol_fees_owed_a"
+                              },
+                              "val": {
+                                "i128": {
+                                  "hi": 0,
+                                  "lo": 0
+                                }
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "protocol_fees_owed_b"
+                              },
+                              "val": {
+                                "i128": {
+                                  "hi": 0,
+                                  "lo": 0
+                                }
+                              }
+                            },
+                            {
+                              "key": {
                                 "symbol": "reserve_a"
                               },
                               "val": {

--- a/contracts/pair/test_snapshots/test/initialize/get_reserves_returns_zeros_after_init.1.json
+++ b/contracts/pair/test_snapshots/test/initialize/get_reserves_returns_zeros_after_init.1.json
@@ -221,6 +221,28 @@
                             },
                             {
                               "key": {
+                                "symbol": "protocol_fees_owed_a"
+                              },
+                              "val": {
+                                "i128": {
+                                  "hi": 0,
+                                  "lo": 0
+                                }
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "protocol_fees_owed_b"
+                              },
+                              "val": {
+                                "i128": {
+                                  "hi": 0,
+                                  "lo": 0
+                                }
+                              }
+                            },
+                            {
+                              "key": {
                                 "symbol": "reserve_a"
                               },
                               "val": {

--- a/contracts/pair/test_snapshots/test/initialize/happy_path_initializes_all_state.1.json
+++ b/contracts/pair/test_snapshots/test/initialize/happy_path_initializes_all_state.1.json
@@ -223,6 +223,28 @@
                             },
                             {
                               "key": {
+                                "symbol": "protocol_fees_owed_a"
+                              },
+                              "val": {
+                                "i128": {
+                                  "hi": 0,
+                                  "lo": 0
+                                }
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "protocol_fees_owed_b"
+                              },
+                              "val": {
+                                "i128": {
+                                  "hi": 0,
+                                  "lo": 0
+                                }
+                              }
+                            },
+                            {
+                              "key": {
                                 "symbol": "reserve_a"
                               },
                               "val": {

--- a/contracts/pair/test_snapshots/test/initialize/pair_state_stores_correct_addresses.1.json
+++ b/contracts/pair/test_snapshots/test/initialize/pair_state_stores_correct_addresses.1.json
@@ -221,6 +221,28 @@
                             },
                             {
                               "key": {
+                                "symbol": "protocol_fees_owed_a"
+                              },
+                              "val": {
+                                "i128": {
+                                  "hi": 0,
+                                  "lo": 0
+                                }
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "protocol_fees_owed_b"
+                              },
+                              "val": {
+                                "i128": {
+                                  "hi": 0,
+                                  "lo": 0
+                                }
+                              }
+                            },
+                            {
+                              "key": {
                                 "symbol": "reserve_a"
                               },
                               "val": {

--- a/contracts/pair/test_snapshots/test/mint/test_dust_deposit_fails.1.json
+++ b/contracts/pair/test_snapshots/test/mint/test_dust_deposit_fails.1.json
@@ -645,6 +645,28 @@
                             },
                             {
                               "key": {
+                                "symbol": "protocol_fees_owed_a"
+                              },
+                              "val": {
+                                "i128": {
+                                  "hi": 0,
+                                  "lo": 0
+                                }
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "protocol_fees_owed_b"
+                              },
+                              "val": {
+                                "i128": {
+                                  "hi": 0,
+                                  "lo": 0
+                                }
+                              }
+                            },
+                            {
+                              "key": {
                                 "symbol": "reserve_a"
                               },
                               "val": {

--- a/contracts/pair/test_snapshots/test/mint/test_first_deposit.1.json
+++ b/contracts/pair/test_snapshots/test/mint/test_first_deposit.1.json
@@ -808,6 +808,28 @@
                             },
                             {
                               "key": {
+                                "symbol": "protocol_fees_owed_a"
+                              },
+                              "val": {
+                                "i128": {
+                                  "hi": 0,
+                                  "lo": 0
+                                }
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "protocol_fees_owed_b"
+                              },
+                              "val": {
+                                "i128": {
+                                  "hi": 0,
+                                  "lo": 0
+                                }
+                              }
+                            },
+                            {
+                              "key": {
                                 "symbol": "reserve_a"
                               },
                               "val": {

--- a/contracts/pair/test_snapshots/test/mint/test_price_accumulation.1.json
+++ b/contracts/pair/test_snapshots/test/mint/test_price_accumulation.1.json
@@ -807,6 +807,28 @@
                             },
                             {
                               "key": {
+                                "symbol": "protocol_fees_owed_a"
+                              },
+                              "val": {
+                                "i128": {
+                                  "hi": 0,
+                                  "lo": 0
+                                }
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "protocol_fees_owed_b"
+                              },
+                              "val": {
+                                "i128": {
+                                  "hi": 0,
+                                  "lo": 0
+                                }
+                              }
+                            },
+                            {
+                              "key": {
                                 "symbol": "reserve_a"
                               },
                               "val": {

--- a/contracts/pair/test_snapshots/test/mint/test_proportional_deposit.1.json
+++ b/contracts/pair/test_snapshots/test/mint/test_proportional_deposit.1.json
@@ -1050,6 +1050,28 @@
                             },
                             {
                               "key": {
+                                "symbol": "protocol_fees_owed_a"
+                              },
+                              "val": {
+                                "i128": {
+                                  "hi": 0,
+                                  "lo": 0
+                                }
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "protocol_fees_owed_b"
+                              },
+                              "val": {
+                                "i128": {
+                                  "hi": 0,
+                                  "lo": 0
+                                }
+                              }
+                            },
+                            {
+                              "key": {
                                 "symbol": "reserve_a"
                               },
                               "val": {

--- a/contracts/pair/test_snapshots/test/sync/test_sync_emits_event.1.json
+++ b/contracts/pair/test_snapshots/test/sync/test_sync_emits_event.1.json
@@ -220,6 +220,28 @@
                             },
                             {
                               "key": {
+                                "symbol": "protocol_fees_owed_a"
+                              },
+                              "val": {
+                                "i128": {
+                                  "hi": 0,
+                                  "lo": 0
+                                }
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "protocol_fees_owed_b"
+                              },
+                              "val": {
+                                "i128": {
+                                  "hi": 0,
+                                  "lo": 0
+                                }
+                              }
+                            },
+                            {
+                              "key": {
                                 "symbol": "reserve_a"
                               },
                               "val": {

--- a/contracts/pair/test_snapshots/test/sync/test_sync_no_price_update_no_time.1.json
+++ b/contracts/pair/test_snapshots/test/sync/test_sync_no_price_update_no_time.1.json
@@ -222,6 +222,28 @@
                             },
                             {
                               "key": {
+                                "symbol": "protocol_fees_owed_a"
+                              },
+                              "val": {
+                                "i128": {
+                                  "hi": 0,
+                                  "lo": 0
+                                }
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "protocol_fees_owed_b"
+                              },
+                              "val": {
+                                "i128": {
+                                  "hi": 0,
+                                  "lo": 0
+                                }
+                              }
+                            },
+                            {
+                              "key": {
                                 "symbol": "reserve_a"
                               },
                               "val": {

--- a/contracts/pair/test_snapshots/test/sync/test_sync_resets_reserves.1.json
+++ b/contracts/pair/test_snapshots/test/sync/test_sync_resets_reserves.1.json
@@ -221,6 +221,28 @@
                             },
                             {
                               "key": {
+                                "symbol": "protocol_fees_owed_a"
+                              },
+                              "val": {
+                                "i128": {
+                                  "hi": 0,
+                                  "lo": 0
+                                }
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "protocol_fees_owed_b"
+                              },
+                              "val": {
+                                "i128": {
+                                  "hi": 0,
+                                  "lo": 0
+                                }
+                              }
+                            },
+                            {
+                              "key": {
                                 "symbol": "reserve_a"
                               },
                               "val": {

--- a/contracts/pair/test_snapshots/test/sync/test_sync_succeeds_after_init.1.json
+++ b/contracts/pair/test_snapshots/test/sync/test_sync_succeeds_after_init.1.json
@@ -221,6 +221,28 @@
                             },
                             {
                               "key": {
+                                "symbol": "protocol_fees_owed_a"
+                              },
+                              "val": {
+                                "i128": {
+                                  "hi": 0,
+                                  "lo": 0
+                                }
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "protocol_fees_owed_b"
+                              },
+                              "val": {
+                                "i128": {
+                                  "hi": 0,
+                                  "lo": 0
+                                }
+                              }
+                            },
+                            {
+                              "key": {
                                 "symbol": "reserve_a"
                               },
                               "val": {

--- a/contracts/pair/test_snapshots/test/sync/test_sync_updates_cumulative_prices_with_time.1.json
+++ b/contracts/pair/test_snapshots/test/sync/test_sync_updates_cumulative_prices_with_time.1.json
@@ -221,6 +221,28 @@
                             },
                             {
                               "key": {
+                                "symbol": "protocol_fees_owed_a"
+                              },
+                              "val": {
+                                "i128": {
+                                  "hi": 0,
+                                  "lo": 0
+                                }
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "protocol_fees_owed_b"
+                              },
+                              "val": {
+                                "i128": {
+                                  "hi": 0,
+                                  "lo": 0
+                                }
+                              }
+                            },
+                            {
+                              "key": {
                                 "symbol": "reserve_a"
                               },
                               "val": {

--- a/contracts/pair/test_snapshots/test/views/test_get_current_fee_bps_initialized_no_volatility.1.json
+++ b/contracts/pair/test_snapshots/test/views/test_get_current_fee_bps_initialized_no_volatility.1.json
@@ -221,6 +221,28 @@
                             },
                             {
                               "key": {
+                                "symbol": "protocol_fees_owed_a"
+                              },
+                              "val": {
+                                "i128": {
+                                  "hi": 0,
+                                  "lo": 0
+                                }
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "protocol_fees_owed_b"
+                              },
+                              "val": {
+                                "i128": {
+                                  "hi": 0,
+                                  "lo": 0
+                                }
+                              }
+                            },
+                            {
+                              "key": {
                                 "symbol": "reserve_a"
                               },
                               "val": {

--- a/contracts/pair/test_snapshots/test/views/test_get_reserves_after_state_change.1.json
+++ b/contracts/pair/test_snapshots/test/views/test_get_reserves_after_state_change.1.json
@@ -109,6 +109,28 @@
                             },
                             {
                               "key": {
+                                "symbol": "protocol_fees_owed_a"
+                              },
+                              "val": {
+                                "i128": {
+                                  "hi": 0,
+                                  "lo": 0
+                                }
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "protocol_fees_owed_b"
+                              },
+                              "val": {
+                                "i128": {
+                                  "hi": 0,
+                                  "lo": 0
+                                }
+                              }
+                            },
+                            {
+                              "key": {
                                 "symbol": "reserve_a"
                               },
                               "val": {

--- a/contracts/pair/test_snapshots/test/views/test_get_reserves_initialized.1.json
+++ b/contracts/pair/test_snapshots/test/views/test_get_reserves_initialized.1.json
@@ -221,6 +221,28 @@
                             },
                             {
                               "key": {
+                                "symbol": "protocol_fees_owed_a"
+                              },
+                              "val": {
+                                "i128": {
+                                  "hi": 0,
+                                  "lo": 0
+                                }
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "protocol_fees_owed_b"
+                              },
+                              "val": {
+                                "i128": {
+                                  "hi": 0,
+                                  "lo": 0
+                                }
+                              }
+                            },
+                            {
+                              "key": {
                                 "symbol": "reserve_a"
                               },
                               "val": {

--- a/contracts/router/src/errors.rs
+++ b/contracts/router/src/errors.rs
@@ -14,4 +14,5 @@ pub enum RouterError {
     InsufficientLiquidity = 307,
     SlippageExceeded = 308,
     InternalError = 309,
+    TransactionExpired = 310,
 }

--- a/contracts/router/src/lib.rs
+++ b/contracts/router/src/lib.rs
@@ -11,7 +11,7 @@ mod storage;
 mod test;
 
 use errors::RouterError;
-use helpers::{compute_optimal_amounts, get_pair_address, PairClient};
+use helpers::{compute_optimal_amounts, get_amount_in, get_amount_out, get_pair_address, sort_tokens, PairClient};
 use soroban_sdk::{contract, contractimpl, token::TokenClient, Address, Env, Vec};
 use storage::{get_factory, set_factory};
 
@@ -24,33 +24,170 @@ impl Router {
         set_factory(&env, &factory);
     }
     pub fn swap_exact_tokens_for_tokens(
-        _env: Env,
-        _amount_in: i128,
-        _amount_out_min: i128,
-        _path: Vec<Address>,
-        _to: Address,
-        _deadline: u64,
+        env: Env,
+        amount_in: i128,
+        amount_out_min: i128,
+        path: Vec<Address>,
+        to: Address,
+        deadline: u64,
     ) -> Result<Vec<i128>, RouterError> {
-        todo!()
+        // Check deadline (ledger sequence)
+        if env.ledger().sequence() > deadline as u32 {
+            return Err(RouterError::TransactionExpired);
+        }
+
+        if amount_in <= 0 {
+            return Err(RouterError::ZeroAmount);
+        }
+
+        if path.len() < 2 {
+            return Err(RouterError::InvalidPath);
+        }
+
+        let factory = get_factory(&env).ok_or(RouterError::PairNotFound)?;
+        let mut amounts = Vec::new(&env);
+        amounts.push_back(amount_in);
+
+        for i in 0..path.len() - 1 {
+            let token_in = path.get(i).unwrap();
+            let token_out = path.get(i + 1).unwrap();
+
+            let pair_address = get_pair_address(&env, &factory, &token_in, &token_out)?;
+            let pair_client = PairClient::new(&env, &pair_address);
+            let (reserve_a, reserve_b, _) = pair_client.get_reserves();
+            let fee_bps = pair_client.get_current_fee_bps();
+
+            let (reserve_in, reserve_out) =
+                if token_in < token_out { (reserve_a, reserve_b) } else { (reserve_b, reserve_a) };
+
+            let amount_out = get_amount_out(&env, amounts.get(i).unwrap(), reserve_in, reserve_out, fee_bps)?;
+            amounts.push_back(amount_out);
+
+            if i == path.len() - 2 {
+                // Last hop — output must meet minimum
+                if amount_out < amount_out_min {
+                    return Err(RouterError::SlippageExceeded);
+                }
+
+                // Determine (amount_a_out, amount_b_out) based on pair canonical ordering
+                let (sorted_a, _) = sort_tokens(&token_in, &token_out)?;
+                let (amount_a_out, amount_b_out) = if token_in == sorted_a {
+                    (0i128, amount_out)
+                } else {
+                    (amount_out, 0i128)
+                };
+
+                // Transfer input tokens from user to the pair
+                let amount_in_this_hop = amounts.get(i).unwrap();
+                to.require_auth();
+                TokenClient::new(&env, &token_in).transfer(&to, &pair_address, &amount_in_this_hop);
+
+                pair_client.swap(&amount_a_out, &amount_b_out, &to);
+            } else {
+                // Intermediate hop: transfer to the next pair, the output goes to the next pair
+                // For simplicity in single-hop paths this won't be reached
+                let amount_in_this_hop = amounts.get(i).unwrap();
+                to.require_auth();
+                TokenClient::new(&env, &token_in).transfer(&to, &pair_address, &amount_in_this_hop);
+
+                let next_pair_address =
+                    get_pair_address(&env, &factory, &token_out, &path.get(i + 2).unwrap())?;
+
+                let (sorted_a, _) = sort_tokens(&token_in, &token_out)?;
+                let (amount_a_out, amount_b_out) = if token_in == sorted_a {
+                    (0i128, amount_out)
+                } else {
+                    (amount_out, 0i128)
+                };
+
+                pair_client.swap(&amount_a_out, &amount_b_out, &next_pair_address);
+            }
+        }
+
+        Ok(amounts)
     }
 
-    /// Swaps tokens to receive an exact amount of output tokens (not yet implemented).
-    ///
-    /// # Arguments
-    /// * `amount_out` - The exact amount of output tokens desired
-    /// * `amount_in_max` - The maximum amount of input tokens to spend
-    /// * `path` - Vector of token addresses representing the swap route
-    /// * `to` - The recipient address for output tokens
-    /// * `deadline` - Unix timestamp after which the transaction will revert
+    /// Swaps tokens to receive an exact amount of output tokens.
     pub fn swap_tokens_for_exact_tokens(
-        _env: Env,
-        _amount_out: i128,
-        _amount_in_max: i128,
-        _path: Vec<Address>,
-        _to: Address,
-        _deadline: u64,
+        env: Env,
+        amount_out: i128,
+        amount_in_max: i128,
+        path: Vec<Address>,
+        to: Address,
+        deadline: u64,
     ) -> Result<Vec<i128>, RouterError> {
-        todo!()
+        // Check deadline (ledger sequence)
+        if env.ledger().sequence() > deadline as u32 {
+            return Err(RouterError::TransactionExpired);
+        }
+
+        if amount_out <= 0 {
+            return Err(RouterError::ZeroAmount);
+        }
+
+        if path.len() < 2 {
+            return Err(RouterError::InvalidPath);
+        }
+
+        let factory = get_factory(&env).ok_or(RouterError::PairNotFound)?;
+
+        // Compute required input amounts backwards through the path
+        let mut amounts = Vec::new(&env);
+        amounts.push_back(amount_out);
+
+        for i in (0..path.len() - 1).rev() {
+            let token_in = path.get(i).unwrap();
+            let token_out = path.get(i + 1).unwrap();
+
+            let pair_address = get_pair_address(&env, &factory, &token_in, &token_out)?;
+            let pair_client = PairClient::new(&env, &pair_address);
+            let (reserve_a, reserve_b, _) = pair_client.get_reserves();
+            let fee_bps = pair_client.get_current_fee_bps();
+
+            let (reserve_in, reserve_out) =
+                if token_in < token_out { (reserve_a, reserve_b) } else { (reserve_b, reserve_a) };
+
+            let amount_in =
+                get_amount_in(&env, amounts.get(0).unwrap(), reserve_in, reserve_out, fee_bps)?;
+            amounts.insert(0, amount_in);
+        }
+
+        let total_amount_in = amounts.get(0).unwrap();
+        if total_amount_in > amount_in_max {
+            return Err(RouterError::ExcessiveInputAmount);
+        }
+
+        // Execute swaps forward
+        to.require_auth();
+
+        for i in 0..path.len() - 1 {
+            let token_in = path.get(i).unwrap();
+            let token_out = path.get(i + 1).unwrap();
+            let amount_in_this = amounts.get(i).unwrap();
+            let amount_out_this = amounts.get(i + 1).unwrap();
+
+            let pair_address = get_pair_address(&env, &factory, &token_in, &token_out)?;
+            let pair_client = PairClient::new(&env, &pair_address);
+
+            TokenClient::new(&env, &token_in).transfer(&to, &pair_address, &amount_in_this);
+
+            let recipient = if i == path.len() - 2 {
+                to.clone()
+            } else {
+                get_pair_address(&env, &factory, &token_out, &path.get(i + 2).unwrap())?
+            };
+
+            let (sorted_a, _) = sort_tokens(&token_in, &token_out)?;
+            let (amount_a_out, amount_b_out) = if token_in == sorted_a {
+                (0i128, amount_out_this)
+            } else {
+                (amount_out_this, 0i128)
+            };
+
+            pair_client.swap(&amount_a_out, &amount_b_out, &recipient);
+        }
+
+        Ok(amounts)
     }
 
     /// Adds liquidity to a token pair (not yet implemented).


### PR DESCRIPTION
## #138 - Protocol Fee Accumulation & Collection
- Pair accumulates protocol fees during swaps by querying factory's `get_fee_bps()`
- `collect_fees()` transfers accumulated fees to factory's `fee_to` address
- Factory has `get_fee_bps()` and `collect_protocol_fees(pairs)` with authorization
- New `ProtocolFeesCollected` and `collect_fees` events

## #141 - Router Swap Deadline Checks
- `swap_exact_tokens_for_tokens` with ledger-sequence deadline check, multi-hop support
- `swap_tokens_for_exact_tokens` with backward amount computation
- Added `TransactionExpired` error variant


Closes #138
Closes #141