### PR TITLE
closing issue #136

### DIFF
--- a/contracts/lp_token/src/errors.rs
+++ b/contracts/lp_token/src/errors.rs
@@ -12,4 +12,6 @@ pub enum LpTokenError {
     Overflow = 205,
     InvalidExpiration = 206,
     ContractPaused = 207,
+    PermitExpired = 208,
+    InvalidSignature = 209,
 }

--- a/contracts/lp_token/src/lib.rs
+++ b/contracts/lp_token/src/lib.rs
@@ -9,7 +9,7 @@ mod errors;
 mod storage;
 
 use errors::LpTokenError;
-use soroban_sdk::{contract, contractimpl, Address, Env, String};
+use soroban_sdk::{contract, contractimpl, Address, Bytes, BytesN, Env, String, xdr::ToXdr};
 use storage::{AllowanceEntry, LpTokenKey, TokenMetadata};
 
 #[contract]
@@ -142,6 +142,74 @@ impl LpToken {
         } else {
             0
         }
+    }
+
+    /// Get the current permit nonce for an owner
+    pub fn nonce(env: Env, owner: Address) -> u64 {
+        env.storage()
+            .persistent()
+            .get::<LpTokenKey, u64>(&LpTokenKey::Nonce(owner))
+            .unwrap_or(0)
+    }
+
+    /// Approve spender via off-chain signature (SEP-41 permit)
+    pub fn permit(
+        env: Env,
+        owner: Address,
+        spender: Address,
+        amount: i128,
+        deadline: u32,
+        signature: BytesN<64>,
+    ) -> Result<(), LpTokenError> {
+        if env.ledger().sequence() > deadline {
+            return Err(LpTokenError::PermitExpired);
+        }
+
+        let nonce = Self::nonce(env.clone(), owner.clone());
+        let digest = Self::permit_digest(&env, &owner, &spender, amount, nonce, deadline);
+
+        let public_key = match owner {
+            Address::Account(pk) => pk,
+            _ => return Err(LpTokenError::InvalidSignature),
+        };
+
+        let valid = env.crypto().ed25519_verify(&digest, &signature, &public_key);
+        if !valid {
+            return Err(LpTokenError::InvalidSignature);
+        }
+
+        let key = LpTokenKey::Allowance(owner.clone(), spender.clone());
+        let allowance_entry = AllowanceEntry {
+            amount,
+            expiration_ledger: deadline,
+        };
+        env.storage().persistent().set(&key, &allowance_entry);
+
+        let ledgers_to_live = deadline.saturating_sub(env.ledger().sequence());
+        env.storage().persistent().extend_ttl(&key, ledgers_to_live, ledgers_to_live);
+
+        env.storage()
+            .persistent()
+            .set(&LpTokenKey::Nonce(owner.clone()), &(nonce + 1));
+
+        Ok(())
+    }
+
+    fn permit_digest(
+        env: &Env,
+        owner: &Address,
+        spender: &Address,
+        amount: i128,
+        nonce: u64,
+        deadline: u32,
+    ) -> BytesN<32> {
+        let mut data = Bytes::new(env);
+        data.append(&owner.clone().to_xdr(env));
+        data.append(&spender.clone().to_xdr(env));
+        data.append(&amount.to_be_bytes());
+        data.append(&nonce.to_be_bytes());
+        data.append(&deadline.to_be_bytes());
+        env.crypto().sha256(&data)
     }
 
     /// Set allowance for spender to transfer from `from`

--- a/contracts/lp_token/src/storage.rs
+++ b/contracts/lp_token/src/storage.rs
@@ -21,4 +21,5 @@ pub enum LpTokenKey {
     Metadata,
     Admin,
     Paused,
+    Nonce(Address),
 }

--- a/contracts/lp_token/src/test/mod.rs
+++ b/contracts/lp_token/src/test/mod.rs
@@ -6,9 +6,14 @@ use crate::errors::LpTokenError;
 use soroban_sdk::{
     testutils::Address as _,
     Address,
+    Bytes,
+    BytesN,
     Env,
     Ledger,
+    String,
+    xdr::ToXdr,
 };
+use ed25519_dalek::{Keypair, PublicKey, SecretKey, Signer};
 
 #[test]
 fn test_contract_compiles() {
@@ -57,4 +62,147 @@ fn test_approve_allows_future_expiration_and_transfer_from_deducts_allowance() {
     assert_eq!(client.allowance(&owner, &spender), 75);
     assert_eq!(client.balance(&receiver), 25);
     assert_eq!(client.balance(&owner), 75);
+}
+
+// ── Permit (SEP-41) Tests ────────────────────────────────────────────────────
+
+fn make_keypair() -> Keypair {
+    let mut seed = [0u8; 64];
+    seed[..32].copy_from_slice(&[1u8; 32]);
+    let secret = SecretKey::from_bytes(&seed[..32]).unwrap();
+    let public = PublicKey::from(&secret);
+    seed[32..].copy_from_slice(&public.to_bytes());
+    Keypair::from_bytes(&seed).unwrap()
+}
+
+fn owner_address(env: &Env, keypair: &Keypair) -> Address {
+    let pk = BytesN::from_array(env, &keypair.public.to_bytes());
+    Address::Account(pk)
+}
+
+fn permit_digest(env: &Env, owner: &Address, spender: &Address, amount: i128, nonce: u64, deadline: u32) -> BytesN<32> {
+    let mut data = Bytes::new(env);
+    data.append(&owner.clone().to_xdr(env));
+    data.append(&spender.clone().to_xdr(env));
+    data.append(&amount.to_be_bytes());
+    data.append(&nonce.to_be_bytes());
+    data.append(&deadline.to_be_bytes());
+    env.crypto().sha256(&data)
+}
+
+fn sign_permit(env: &Env, keypair: &Keypair, owner: &Address, spender: &Address, amount: i128, nonce: u64, deadline: u32) -> BytesN<64> {
+    let digest = permit_digest(env, owner, spender, amount, nonce, deadline);
+    let signature = keypair.sign(digest.as_ref());
+    BytesN::from_array(env, &signature.to_bytes())
+}
+
+#[test]
+fn test_permit_approves_spender_without_on_chain_approval() {
+    let env = Env::default();
+    env.mock_all_auths_allowing_non_root_auth();
+    let contract_id = env.register_contract(None, LpToken);
+    let client = LpTokenClient::new(&env, &contract_id);
+    
+    let owner_keys = make_keypair();
+    let owner = owner_address(&env, &owner_keys);
+    let spender = Address::generate(&env);
+    let recipient = Address::generate(&env);
+    let amount = 1_000_i128;
+    let deadline = env.ledger().sequence() + 10;
+
+    // Mint tokens to owner
+    env.as_contract(&contract_id, || {
+        env.storage()
+            .persistent()
+            .set(&LpTokenKey::Balance(owner.clone()), &amount);
+    });
+
+    // Check initial nonce is 0
+    let nonce = client.nonce(&owner);
+    assert_eq!(nonce, 0);
+
+    // Sign permit
+    let signature = sign_permit(&env, &owner_keys, &owner, &spender, amount, nonce, deadline);
+
+    // Execute permit
+    let permit_result = client.try_permit(&owner, &spender, &amount, &deadline, &signature);
+    assert!(permit_result.is_ok());
+
+    // Verify allowance was set
+    assert_eq!(client.allowance(&owner, &spender), amount);
+
+    // Verify transfer_from works with permit-set allowance
+    client.transfer_from(&spender, &owner, &recipient, &amount).unwrap();
+    assert_eq!(client.balance(&recipient), amount);
+}
+
+#[test]
+fn test_permit_expired_deadline_reverts() {
+    let env = Env::default();
+    env.mock_all_auths_allowing_non_root_auth();
+    let contract_id = env.register_contract(None, LpToken);
+    let client = LpTokenClient::new(&env, &contract_id);
+    
+    let owner_keys = make_keypair();
+    let owner = owner_address(&env, &owner_keys);
+    let spender = Address::generate(&env);
+    let amount = 1_000_i128;
+    let deadline = env.ledger().sequence().saturating_sub(1);
+    let nonce = 0;
+
+    let signature = sign_permit(&env, &owner_keys, &owner, &spender, amount, nonce, deadline);
+    let result = client.try_permit(&owner, &spender, &amount, &deadline, &signature);
+
+    assert_eq!(result, Err(Ok(LpTokenError::PermitExpired)));
+}
+
+#[test]
+fn test_permit_replayed_nonce_reverts() {
+    let env = Env::default();
+    env.mock_all_auths_allowing_non_root_auth();
+    let contract_id = env.register_contract(None, LpToken);
+    let client = LpTokenClient::new(&env, &contract_id);
+    
+    let owner_keys = make_keypair();
+    let owner = owner_address(&env, &owner_keys);
+    let spender = Address::generate(&env);
+    let amount = 1_000_i128;
+    let deadline = env.ledger().sequence() + 10;
+
+    let nonce = client.nonce(&owner);
+    let signature = sign_permit(&env, &owner_keys, &owner, &spender, amount, nonce, deadline);
+
+    // First permit should succeed
+    let first_result = client.try_permit(&owner, &spender, &amount, &deadline, &signature);
+    assert!(first_result.is_ok());
+
+    // Nonce should be incremented
+    let new_nonce = client.nonce(&owner);
+    assert_eq!(new_nonce, nonce + 1);
+
+    // Replaying the same signature should fail
+    let replay_result = client.try_permit(&owner, &spender, &amount, &deadline, &signature);
+    assert_eq!(replay_result, Err(Ok(LpTokenError::InvalidSignature)));
+}
+
+#[test]
+fn test_permit_invalid_signature_reverts() {
+    let env = Env::default();
+    env.mock_all_auths_allowing_non_root_auth();
+    let contract_id = env.register_contract(None, LpToken);
+    let client = LpTokenClient::new(&env, &contract_id);
+    
+    let owner_keys = make_keypair();
+    let owner = owner_address(&env, &owner_keys);
+    let spender = Address::generate(&env);
+    let amount = 1_000_i128;
+    let deadline = env.ledger().sequence() + 10;
+    let nonce = 0;
+
+    // Sign for a different amount
+    let bad_signature = sign_permit(&env, &owner_keys, &owner, &spender, amount + 1, nonce, deadline);
+
+    // Try to use bad signature with original amount
+    let result = client.try_permit(&owner, &spender, &amount, &deadline, &bad_signature);
+    assert_eq!(result, Err(Ok(LpTokenError::InvalidSignature)));
 }


### PR DESCRIPTION
## PR Description

### Summary
Add SEP-41 `permit()` support to the LP token contract so liquidity providers can approve LP transfers off-chain with an Ed25519 signature instead of requiring an extra on-chain approval transaction.

### What changed
- Added `permit(owner, spender, amount, deadline, signature)` to lib.rs
- Implemented typed permit digest hashing over `(owner, spender, amount, nonce, deadline)`
- Verified Ed25519 signatures using the owner’s `Address::Account` public key
- Added per-owner nonces in storage.rs to prevent replay attacks
- Added error cases to errors.rs:
  - `LpTokenError::PermitExpired`
  - `LpTokenError::InvalidSignature`
- Added unit tests in mod.rs covering:
  - valid permit approval
  - permit expiry
  - nonce replay rejection
  - invalid signature rejection
- Enabled `soroban-sdk` test utilities and added `ed25519-dalek` to dev dependencies in Cargo.toml

### Testing
- New tests verify:
  1. valid permit approves allowance and allows `transfer_from`
  2. expired deadline reverts with `PermitExpired`
  3. replayed nonce rejects with `InvalidSignature`
  4. bad signature rejects with `InvalidSignature`

### Notes
- The permit flow now allows Blend/composable DeFi on Stellar to approve LP token transfers with a signed off-chain message.
- The implementation follows the SEP-41 permit pattern and maintains backwards-compatible allowance semantics.

closes #136 