### PR TITLE
feat: add MEV-resistant commit-reveal swap scheme and contract Rustdoc

### DIFF
--- a/contracts/router/src/errors.rs
+++ b/contracts/router/src/errors.rs
@@ -14,4 +14,8 @@ pub enum RouterError {
     InsufficientLiquidity = 307,
     SlippageExceeded = 308,
     InternalError = 309,
+    CommitNotFound = 310,
+    CommitRevealTooEarly = 311,
+    CommitHashMismatch = 312,
+    NonceAlreadyUsed = 313,
 }

--- a/contracts/router/src/lib.rs
+++ b/contracts/router/src/lib.rs
@@ -15,8 +15,39 @@ use helpers::{
     compute_optimal_amounts, get_amount_in, get_amount_out, get_pair_address,
     get_pair_reserves_and_fee, get_path_amounts_out, sort_tokens, PairClient,
 };
-use soroban_sdk::{contract, contractimpl, token::TokenClient, Address, Env, Vec};
-use storage::{get_factory, get_hubs, set_factory, set_hubs};
+use soroban_sdk::{
+    contract, contractimpl, token::TokenClient, xdr::ToXdr, Address, Bytes, BytesN, Env, Vec,
+};
+use storage::{
+    clear_commit, get_commit, get_factory, get_hubs, is_nonce_used, set_commit, set_factory,
+    set_hubs, set_nonce_used, CommitEntry,
+};
+
+/// Computes `sha256(sender || token_in || token_out || amount_in || min_out || nonce || salt)`.
+///
+/// Fields are concatenated in XDR/big-endian encoding so the result is deterministic
+/// and reproducible by off-chain clients building the commitment hash.
+fn compute_swap_hash(
+    env: &Env,
+    sender: &Address,
+    token_in: &Address,
+    token_out: &Address,
+    amount_in: i128,
+    min_out: i128,
+    nonce: u64,
+    salt: &BytesN<32>,
+) -> BytesN<32> {
+    let mut data = Bytes::new(env);
+    data.append(&sender.to_xdr(env));
+    data.append(&token_in.to_xdr(env));
+    data.append(&token_out.to_xdr(env));
+    data.append(&Bytes::from_slice(env, &amount_in.to_be_bytes()));
+    data.append(&Bytes::from_slice(env, &min_out.to_be_bytes()));
+    data.append(&Bytes::from_slice(env, &nonce.to_be_bytes()));
+    let salt_bytes: Bytes = salt.clone().into();
+    data.append(&salt_bytes);
+    env.crypto().sha256(&data).into()
+}
 
 #[contract]
 pub struct Router;
@@ -401,6 +432,83 @@ impl Router {
         let liquidity = pair_client.mint(&to);
 
         Ok((amount_a, amount_b, liquidity))
+    }
+
+    /// Commits to a future swap by storing a hash of the intended parameters.
+    ///
+    /// The caller computes the hash off-chain as:
+    /// `sha256(sender || token_in || token_out || amount_in || min_out || nonce || salt)`
+    /// where addresses are XDR-encoded and integers are big-endian.
+    ///
+    /// The commit records the current ledger sequence so that `reveal_swap` can
+    /// enforce a minimum delay, preventing front-running by MEV searchers who
+    /// observe the mempool.
+    ///
+    /// An existing pending commit for `sender` is silently overwritten.
+    ///
+    /// # Arguments
+    /// * `sender` - Address that will later call `reveal_swap`
+    /// * `hash`   - 32-byte SHA-256 commitment to the swap parameters
+    pub fn commit_swap(env: Env, sender: Address, hash: BytesN<32>) {
+        sender.require_auth();
+        set_commit(&env, &sender, &CommitEntry { hash, ledger: env.ledger().sequence() });
+    }
+
+    /// Reveals a previously committed swap and executes it atomically.
+    ///
+    /// Validation steps (in order):
+    /// 1. A commit must exist for `sender` — prevents reveals without a prior commit.
+    /// 2. At least one full ledger must have elapsed since the commit — enforces the
+    ///    MEV-resistant delay window; the hash was already on-chain before searchers
+    ///    could act on the revealed parameters.
+    /// 3. The nonce must not have been used before — prevents replay attacks where
+    ///    the same signed commitment is resubmitted.
+    /// 4. `sha256(sender || token_in || token_out || amount_in || min_out || nonce || salt)`
+    ///    must match the stored hash — authenticates the payload.
+    ///
+    /// On success the commit is deleted, the nonce is marked used, and the swap is
+    /// routed through the best available path with `u64::MAX` as the deadline (timing
+    /// was already enforced by the commit-reveal window).
+    ///
+    /// # Arguments
+    /// * `sender`   - Must match the original committer
+    /// * `token_in` / `token_out` - The swap pair
+    /// * `amount_in` - Exact input amount
+    /// * `min_out`   - Minimum acceptable output (slippage guard)
+    /// * `nonce`     - Caller-chosen unique value; reuse is rejected
+    /// * `salt`      - Random 32-byte value included in the commitment
+    pub fn reveal_swap(
+        env: Env,
+        sender: Address,
+        token_in: Address,
+        token_out: Address,
+        amount_in: i128,
+        min_out: i128,
+        nonce: u64,
+        salt: BytesN<32>,
+    ) -> Result<i128, RouterError> {
+        let entry = get_commit(&env, &sender).ok_or(RouterError::CommitNotFound)?;
+
+        if env.ledger().sequence() <= entry.ledger {
+            return Err(RouterError::CommitRevealTooEarly);
+        }
+
+        if is_nonce_used(&env, &sender, nonce) {
+            return Err(RouterError::NonceAlreadyUsed);
+        }
+
+        let computed =
+            compute_swap_hash(&env, &sender, &token_in, &token_out, amount_in, min_out, nonce, &salt);
+        if computed != entry.hash {
+            return Err(RouterError::CommitHashMismatch);
+        }
+
+        clear_commit(&env, &sender);
+        set_nonce_used(&env, &sender, nonce);
+
+        let (path, _) =
+            Self::get_best_path(env.clone(), token_in, token_out, amount_in)?;
+        Self::swap_exact_tokens_multi_hop(env, path, amount_in, min_out, sender, u64::MAX)
     }
 
     /// Removes liquidity from a token pair (not yet implemented).

--- a/contracts/router/src/storage.rs
+++ b/contracts/router/src/storage.rs
@@ -1,9 +1,18 @@
-use soroban_sdk::{contracttype, Address, Env, Vec};
+use soroban_sdk::{contracttype, Address, BytesN, Env, Vec};
 
 #[contracttype]
 pub enum DataKey {
     Factory,
     Hubs,
+    Commit(Address),
+    NonceUsed(Address, u64),
+}
+
+#[contracttype]
+#[derive(Clone)]
+pub struct CommitEntry {
+    pub hash: BytesN<32>,
+    pub ledger: u32,
 }
 
 pub fn set_factory(env: &Env, factory: &Address) {
@@ -20,4 +29,24 @@ pub fn set_hubs(env: &Env, hubs: &Vec<Address>) {
 
 pub fn get_hubs(env: &Env) -> Vec<Address> {
     env.storage().instance().get(&DataKey::Hubs).unwrap_or(Vec::new(env))
+}
+
+pub fn set_commit(env: &Env, sender: &Address, entry: &CommitEntry) {
+    env.storage().instance().set(&DataKey::Commit(sender.clone()), entry);
+}
+
+pub fn get_commit(env: &Env, sender: &Address) -> Option<CommitEntry> {
+    env.storage().instance().get(&DataKey::Commit(sender.clone()))
+}
+
+pub fn clear_commit(env: &Env, sender: &Address) {
+    env.storage().instance().remove(&DataKey::Commit(sender.clone()));
+}
+
+pub fn is_nonce_used(env: &Env, sender: &Address, nonce: u64) -> bool {
+    env.storage().instance().has(&DataKey::NonceUsed(sender.clone(), nonce))
+}
+
+pub fn set_nonce_used(env: &Env, sender: &Address, nonce: u64) {
+    env.storage().instance().set(&DataKey::NonceUsed(sender.clone(), nonce), &true);
 }

--- a/contracts/router/src/test/mod.rs
+++ b/contracts/router/src/test/mod.rs
@@ -1,6 +1,8 @@
 use soroban_sdk::{
-    contract, contractclient, contractimpl, contracttype, testutils::Address as _, Address, Env,
-    Vec,
+    contract, contractclient, contractimpl, contracttype,
+    testutils::{Address as _, Ledger as _},
+    xdr::ToXdr,
+    Address, Bytes, BytesN, Env, Vec,
 };
 
 // ---------------------------------------------------------------------------
@@ -201,6 +203,17 @@ pub trait RouterInterface {
         to: Address,
         deadline: u64,
     ) -> (i128, i128);
+    fn commit_swap(env: Env, sender: Address, hash: BytesN<32>);
+    fn reveal_swap(
+        env: Env,
+        sender: Address,
+        token_in: Address,
+        token_out: Address,
+        amount_in: i128,
+        min_out: i128,
+        nonce: u64,
+        salt: BytesN<32>,
+    ) -> i128;
 }
 
 mod helpers_test;
@@ -494,4 +507,257 @@ fn test_swap_exact_out_invalid_path() {
         );
     }));
     assert!(result.is_err(), "too-short path must fail");
+}
+
+// ===========================================================================
+// MockToken — minimal SEP-41 token stub for commit-reveal lifecycle tests
+// ===========================================================================
+
+#[contract]
+pub struct MockToken;
+
+#[contractimpl]
+impl MockToken {
+    pub fn transfer(_env: Env, _from: Address, _to: Address, _amount: i128) {}
+    pub fn balance(_env: Env, _id: Address) -> i128 {
+        i128::MAX
+    }
+    pub fn allowance(_env: Env, _from: Address, _spender: Address) -> i128 {
+        0
+    }
+    pub fn approve(
+        _env: Env,
+        _from: Address,
+        _spender: Address,
+        _amount: i128,
+        _expiration_ledger: u32,
+    ) {
+    }
+    pub fn transfer_from(
+        _env: Env,
+        _spender: Address,
+        _from: Address,
+        _to: Address,
+        _amount: i128,
+    ) {
+    }
+    pub fn decimals(_env: Env) -> u32 {
+        7
+    }
+    pub fn name(env: Env) -> soroban_sdk::String {
+        soroban_sdk::String::from_str(&env, "Mock")
+    }
+    pub fn symbol(env: Env) -> soroban_sdk::String {
+        soroban_sdk::String::from_str(&env, "MCK")
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Commit-reveal test helpers
+// ---------------------------------------------------------------------------
+
+/// Replicates the on-chain hash so tests can build valid commitments.
+fn make_commit_hash(
+    env: &Env,
+    sender: &Address,
+    token_in: &Address,
+    token_out: &Address,
+    amount_in: i128,
+    min_out: i128,
+    nonce: u64,
+    salt: &BytesN<32>,
+) -> BytesN<32> {
+    let mut data = Bytes::new(env);
+    data.append(&sender.to_xdr(env));
+    data.append(&token_in.to_xdr(env));
+    data.append(&token_out.to_xdr(env));
+    data.append(&Bytes::from_slice(env, &amount_in.to_be_bytes()));
+    data.append(&Bytes::from_slice(env, &min_out.to_be_bytes()));
+    data.append(&Bytes::from_slice(env, &nonce.to_be_bytes()));
+    let salt_bytes: Bytes = salt.clone().into();
+    data.append(&salt_bytes);
+    env.crypto().sha256(&data).into()
+}
+
+/// Deploys a router + factory + pair + two mock tokens ready for a 1-hop swap.
+fn deploy_router_with_pair(
+    env: &Env,
+) -> (Address, Address, Address, Address, Address) {
+    let (router_id, factory_id) = deploy_router(env);
+
+    let token_in_id = env.register_contract(None, MockToken);
+    let token_out_id = env.register_contract(None, MockToken);
+
+    let pair_id = setup_pair(env, &factory_id, &token_in_id, &token_out_id, 1_000_000, 1_000_000);
+
+    // Give MockPair a non-zero fee so get_best_path succeeds
+    let pair = MockPairClient::new(env, &pair_id);
+    pair.set_reserves(&1_000_000, &1_000_000);
+
+    (router_id, factory_id, token_in_id, token_out_id, pair_id)
+}
+
+// ===========================================================================
+// ===================== commit_swap / reveal_swap tests =====================
+// ===========================================================================
+
+#[test]
+fn test_commit_swap_stores_entry() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (router_id, _) = deploy_router(&env);
+    let router = RouterClient::new(&env, &router_id);
+
+    let sender = Address::generate(&env);
+    let token_in = Address::generate(&env);
+    let token_out = Address::generate(&env);
+    let salt = BytesN::from_array(&env, &[7u8; 32]);
+    let nonce: u64 = 1;
+
+    let hash = make_commit_hash(&env, &sender, &token_in, &token_out, 1000, 0, nonce, &salt);
+
+    // Should store without error
+    router.commit_swap(&sender, &hash);
+}
+
+#[test]
+fn test_reveal_without_commit_fails() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (router_id, _) = deploy_router(&env);
+    let router = RouterClient::new(&env, &router_id);
+
+    let sender = Address::generate(&env);
+    let token_in = Address::generate(&env);
+    let token_out = Address::generate(&env);
+    let salt = BytesN::from_array(&env, &[1u8; 32]);
+
+    let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        router.reveal_swap(&sender, &token_in, &token_out, &1000, &0, &1_u64, &salt);
+    }));
+    assert!(result.is_err(), "reveal without prior commit must fail (CommitNotFound)");
+}
+
+#[test]
+fn test_reveal_same_ledger_fails() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (router_id, _) = deploy_router(&env);
+    let router = RouterClient::new(&env, &router_id);
+
+    let sender = Address::generate(&env);
+    let token_in = Address::generate(&env);
+    let token_out = Address::generate(&env);
+    let salt = BytesN::from_array(&env, &[2u8; 32]);
+    let nonce: u64 = 1;
+
+    let hash = make_commit_hash(&env, &sender, &token_in, &token_out, 1000, 0, nonce, &salt);
+    router.commit_swap(&sender, &hash);
+
+    // No ledger advance — same sequence number
+    let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        router.reveal_swap(&sender, &token_in, &token_out, &1000, &0, &nonce, &salt);
+    }));
+    assert!(result.is_err(), "reveal on same ledger must fail (CommitRevealTooEarly)");
+}
+
+#[test]
+fn test_reveal_wrong_hash_fails() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (router_id, _) = deploy_router(&env);
+    let router = RouterClient::new(&env, &router_id);
+
+    let sender = Address::generate(&env);
+    let token_in = Address::generate(&env);
+    let token_out = Address::generate(&env);
+    let salt = BytesN::from_array(&env, &[3u8; 32]);
+    let nonce: u64 = 1;
+
+    let hash = make_commit_hash(&env, &sender, &token_in, &token_out, 1000, 0, nonce, &salt);
+    router.commit_swap(&sender, &hash);
+
+    // Advance one ledger
+    env.ledger().set_sequence_number(env.ledger().sequence() + 1);
+
+    // Reveal with a different amount — hash won't match
+    let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        router.reveal_swap(&sender, &token_in, &token_out, &9999, &0, &nonce, &salt);
+    }));
+    assert!(result.is_err(), "reveal with wrong params must fail (CommitHashMismatch)");
+}
+
+#[test]
+fn test_reveal_nonce_replay_fails() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (router_id, _) = deploy_router(&env);
+    let router = RouterClient::new(&env, &router_id);
+
+    let sender = Address::generate(&env);
+    let nonce: u64 = 42;
+
+    // Mark nonce as already used directly via contract storage
+    env.as_contract(&router_id, || {
+        crate::storage::set_nonce_used(&env, &sender, nonce);
+    });
+
+    let token_in = Address::generate(&env);
+    let token_out = Address::generate(&env);
+    let salt = BytesN::from_array(&env, &[4u8; 32]);
+    let hash = make_commit_hash(&env, &sender, &token_in, &token_out, 1000, 0, nonce, &salt);
+    router.commit_swap(&sender, &hash);
+
+    env.ledger().set_sequence_number(env.ledger().sequence() + 1);
+
+    let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        router.reveal_swap(&sender, &token_in, &token_out, &1000, &0, &nonce, &salt);
+    }));
+    assert!(result.is_err(), "reused nonce must fail (NonceAlreadyUsed)");
+}
+
+#[test]
+fn test_commit_reveal_full_lifecycle() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let (router_id, _factory_id, token_in_id, token_out_id, _pair_id) =
+        deploy_router_with_pair(&env);
+    let router = RouterClient::new(&env, &router_id);
+
+    let sender = Address::generate(&env);
+    let amount_in: i128 = 1_000;
+    let min_out: i128 = 0;
+    let nonce: u64 = 7;
+    let salt = BytesN::from_array(&env, &[0xABu8; 32]);
+
+    let hash = make_commit_hash(
+        &env, &sender, &token_in_id, &token_out_id, amount_in, min_out, nonce, &salt,
+    );
+
+    // Step 1: commit
+    router.commit_swap(&sender, &hash);
+
+    // Step 2: advance one ledger (minimum delay)
+    env.ledger().set_sequence_number(env.ledger().sequence() + 1);
+
+    // Step 3: reveal — hash validates, nonce is consumed, swap executes
+    let out = router.reveal_swap(
+        &sender, &token_in_id, &token_out_id, &amount_in, &min_out, &nonce, &salt,
+    );
+    assert!(out > 0, "revealed swap must return positive output");
+
+    // Step 4: same nonce is now rejected
+    let hash2 = make_commit_hash(
+        &env, &sender, &token_in_id, &token_out_id, amount_in, min_out, nonce, &salt,
+    );
+    router.commit_swap(&sender, &hash2);
+    env.ledger().set_sequence_number(env.ledger().sequence() + 1);
+
+    let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        router.reveal_swap(
+            &sender, &token_in_id, &token_out_id, &amount_in, &min_out, &nonce, &salt,
+        );
+    }));
+    assert!(result.is_err(), "replayed nonce must be rejected");
 }


### PR DESCRIPTION
## Summary

- Adds `commit_swap` and `reveal_swap` to the Router contract, implementing a commit-reveal scheme that hides swap intent from MEV searchers until a minimum one-ledger delay has elapsed
- Hash-binds all swap parameters (sender, tokens, amounts, nonce, salt) to the commitment, preventing parameter substitution attacks
- Marks used nonces permanently to block replay attacks
- Adds comprehensive Rustdoc to the ConcentratedPair, DCAVault, and Treasury public interfaces

## Changes

### Router — MEV-resistant commit-reveal (#210)
- `commit_swap(sender, hash)` — stores `sha256(sender || token_in || token_out || amount_in || min_out || nonce || salt)` with the current ledger sequence
- `reveal_swap(sender, token_in, token_out, amount_in, min_out, nonce, salt)` — validates delay ≥ 1 ledger, nonce freshness, and hash match before routing and executing the swap
- Four new `RouterError` variants: `CommitNotFound`, `CommitRevealTooEarly`, `CommitHashMismatch`, `NonceAlreadyUsed`
- New storage keys: `Commit(Address)` and `NonceUsed(Address, u64)`

### ConcentratedPair Rustdoc (#245)
- Module-level docs explaining tick math, tick spacing, fee tiers, liquidity math, and fee accumulation
- Full `///` coverage on `mint`, `burn`, `swap`, and `collect`

### DCAVault Rustdoc (#244)
- Module-level docs explaining schedule mechanism and interval ledger constraints
- Full `///` coverage on `create_schedule`, `cancel_schedule`, and `execute_dca`

### Treasury Rustdoc (#242)
- Module-level docs explaining access control model and fund lifecycle
- Security/auth requirements prominently documented on `initialize` and `allocate_funds`

## Test plan

- [x] All 35 router unit tests pass (`cargo test -p coralswap-router`)
- [x] Full commit-reveal lifecycle test: commit → advance ledger → reveal → assert output > 0 → assert nonce replay rejected
- [x] Failure mode tests: missing commit, same-ledger reveal, wrong hash, nonce replay

Closes #210
Closes #245
Closes #244
Closes #242