### PR TITLE
Fix wasm target compatibility, corrupted lockfile, and factory governance auth bug

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -20,7 +20,7 @@ jobs:
         uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
           toolchain: stable
-          target: wasm32-unknown-unknown
+          target: wasm32v1-none
 
       - name: Cache cargo registry
         uses: actions/cache@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
         with:
-          targets: wasm32-unknown-unknown
+          targets: wasm32v1-none
           components: rustfmt, clippy
       - uses: Swatinem/rust-cache@v2
       - name: Check formatting
@@ -26,7 +26,7 @@ jobs:
       - name: Clippy
         run: cargo clippy --all-targets -- -D warnings
       - name: Build
-        run: cargo build --release --target wasm32-unknown-unknown
+        run: cargo build --release --target wasm32v1-none
       - name: Test
         run: cargo test
       - name: Fuzz tests

--- a/.github/workflows/matrix.yml
+++ b/.github/workflows/matrix.yml
@@ -34,26 +34,34 @@ jobs:
       matrix:
         include:
           # Currently pinned version in Cargo.toml — must pass.
+          # soroban-sdk 21.x predates the reference-types/multi-value features
+          # modern rustc enables by default on wasm32-unknown-unknown, so it
+          # still builds fine on that target.
           - name: stable
             soroban_sdk: "21.7.7"
             soroban_token_sdk: "21.7.7"
             experimental: false
+            wasm_target: wasm32-unknown-unknown
           # Latest published stable line — warn-only.
+          # 26.x+ rejects wasm32-unknown-unknown on Rust 1.82+ (its build.rs
+          # panics) and requires wasm32v1-none instead.
           - name: latest-stable
             soroban_sdk: "26.1.0"
             soroban_token_sdk: "26.1.0"
             experimental: true
+            wasm_target: wasm32v1-none
           # Next preview / release candidate — warn-only.
           - name: preview
             soroban_sdk: "27.0.0-rc.1"
             soroban_token_sdk: "27.0.0-rc.1"
             experimental: true
+            wasm_target: wasm32v1-none
     steps:
       - uses: actions/checkout@v4
 
       - uses: dtolnay/rust-toolchain@stable
         with:
-          targets: wasm32-unknown-unknown
+          targets: wasm32-unknown-unknown,wasm32v1-none
 
       - uses: Swatinem/rust-cache@v2
         with:
@@ -75,7 +83,7 @@ jobs:
 
       - name: Build (wasm release)
         id: build
-        run: cargo build --release --target wasm32-unknown-unknown
+        run: cargo build --release --target ${{ matrix.wasm_target }}
 
       - name: Test
         id: test

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,8 @@
 target/
 *.wasm
+benchmark-results.json
+base-benchmark.json
+pr-benchmark.json
 !test/*.wasm
 .idea/
 .vscode/
@@ -10,7 +13,6 @@ target/
 Thumbs.db
 .env
 .env.local
-*.sh
 target_local/
 issue.md
 pr.md

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -22,9 +22,9 @@ checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
 name = "android_system_properties"
-version = "0.1.5"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
+checksum = "ae221649c9976a6f6c56ae1facf410f3ddb33cc661c4b7b61020a912d4237fbc"
 dependencies = [
  "libc",
 ]
@@ -278,9 +278,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.3.0"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c89588d05638b5b4594a3348a2d6c20277e43a7f5c5202b05cc56888475a47b8"
+checksum = "5add81bb678e6cb321aff7fa0dc7689ad82b112dbc032cea19f91d6b8e3582b9"
 dependencies = [
  "find-msvc-tools",
  "shlex",
@@ -351,6 +351,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "coralswap-malicious-flash-receiver"
+version = "0.1.0"
+dependencies = [
+ "coralswap-flash-receiver-interface",
+ "coralswap-pair",
+ "soroban-sdk",
+]
+
+[[package]]
 name = "coralswap-mock-flash-receiver"
 version = "0.1.0"
 dependencies = [
@@ -365,6 +374,7 @@ version = "0.1.0"
 dependencies = [
  "coralswap-flash-receiver-interface",
  "coralswap-lp-token",
+ "coralswap-malicious-flash-receiver",
  "coralswap-mock-flash-receiver",
  "ethnum",
  "soroban-sdk",
@@ -583,9 +593,9 @@ dependencies = [
 
 [[package]]
 name = "data-encoding"
-version = "2.11.0"
+version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4ae5f15dda3c708c0ade84bfee31ccab44a3da4f88015ed22f63732abe300c8"
+checksum = "4583a4551df46e2792f82ceeac45e850d2e2d5debba0b91f102385cda5b11f06"
 
 [[package]]
 name = "der"
@@ -718,9 +728,9 @@ dependencies = [
 
 [[package]]
 name = "either"
-version = "1.16.0"
+version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91622ff5e7162018101f2fea40d6ebf4a78bbe5a49736a2020649edf9693679e"
+checksum = "9e5e8f6c15a24b9a3ee5efec809ccd006d3b30e8b3bb63c39af737c7f87daa1d"
 
 [[package]]
 name = "elliptic-curve"
@@ -742,22 +752,22 @@ dependencies = [
 
 [[package]]
 name = "enum-ordinalize"
-version = "4.4.1"
+version = "4.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07f808d588c10e464ea6f7d3eaed500049eff30aaac103460f61828c2d65b3eb"
+checksum = "89dd01549b09589510cf0647475075d12071456586d70f5c75c98ae2a5537677"
 dependencies = [
  "enum-ordinalize-derive",
 ]
 
 [[package]]
 name = "enum-ordinalize-derive"
-version = "4.4.1"
+version = "4.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42e528e2d34ba8a67a1a650b86beae8ef69fc5fdb638016f386b973226590432"
+checksum = "a65863d15a4ce2888bd2f0f543cc963d3879c3a022c8ee43f6141d479a3ac815"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.119",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -787,12 +797,6 @@ name = "ethnum"
 version = "1.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40404c3f5f511ec4da6fe866ddf6a717c309fdbb69fbbad7b0f3edab8f2e835f"
-
-[[package]]
-name = "fastrand"
-version = "2.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da7c62ceae207dd37ea5b845da6a0696c799f85e97da1ab5b7910be3c1c80223"
 
 [[package]]
 name = "fastrand"
@@ -906,29 +910,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "gimli"
-version = "0.32.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
-dependencies = [
- "cfg-if",
- "libc",
- "r-efi 5.3.0",
- "wasip2",
-]
-
-[[package]]
-name = "getrandom"
-version = "0.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "300e883d756b2e4ec94e02791f39b04b522276138852cfc41d9fb7e904106099"
-dependencies = [
- "cfg-if",
- "libc",
- "r-efi 6.0.0",
-]
-
-[[package]]
 name = "group"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1011,9 +992,9 @@ dependencies = [
 
 [[package]]
 name = "hybrid-array"
-version = "0.4.13"
+version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "818356c5132c1fede50f837ca96afbe78ff42413047f4abb886217845e1b6c8c"
+checksum = "707114b52a152fa7bdb290cd7cd5912d9467273b6d74e21b8d81aca1f8533f6b"
 dependencies = [
  "typenum",
 ]
@@ -1139,12 +1120,6 @@ checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 [[package]]
 name = "linux-raw-sys"
 version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
-
-[[package]]
-name = "log"
-version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
@@ -1501,18 +1476,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rusty-fork"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc6bf79ff24e648f6da1f8d1f011e9cac26491b619e6b9280f2b47f1774e6ee2"
-dependencies = [
- "fnv",
- "quick-error",
- "tempfile",
- "wait-timeout",
-]
-
-[[package]]
 name = "schemars"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1526,9 +1489,9 @@ dependencies = [
 
 [[package]]
 name = "schemars"
-version = "1.2.1"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2b42f36aa1cd011945615b92222f6bf73c599a102a300334cd7f8dbeec726cc"
+checksum = "687274d293b6cdc6e73e0fee520bf2049650090d7164f87672d212a3c530cf4a"
 dependencies = [
  "dyn-clone",
  "ref-cast",
@@ -1612,7 +1575,7 @@ dependencies = [
  "indexmap 2.14.0",
  "schemars 0.8.22",
  "schemars 0.9.0",
- "schemars 1.2.1",
+ "schemars 1.2.2",
  "serde_core",
  "serde_json",
  "serde_with_macros",
@@ -1664,7 +1627,7 @@ version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
 dependencies = [
- "digest",
+ "digest 0.10.7",
  "rand_core 0.6.4",
 ]
 
@@ -1745,7 +1708,7 @@ dependencies = [
  "num-integer",
  "num-traits",
  "p256",
- "rand 0.8.5",
+ "rand 0.8.7",
  "rand_chacha 0.3.1",
  "sec1",
  "sha2",
@@ -1775,9 +1738,9 @@ dependencies = [
 
 [[package]]
 name = "soroban-ledger-snapshot"
-version = "27.0.2"
+version = "27.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27ea48b5d5e22c0cbaa370f813111016c9f5a8a6632edb0684c72be6531c4d3a"
+checksum = "b071cbdc453b3fc425bcb7666a4c88f4fc3d09b4abdb1a2b9abb6d017d3ee06a"
 dependencies = [
  "serde",
  "serde_json",
@@ -1789,9 +1752,9 @@ dependencies = [
 
 [[package]]
 name = "soroban-sdk"
-version = "27.0.2"
+version = "27.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6cfa78af0110f0830d3af9db0361b6cdb50507846cedb8725189318134218b80"
+checksum = "0a8575f7d2b50faa0dfdf60bb488496cb3ddb75d71467b385ce9cf1c4b19bc51"
 dependencies = [
  "arbitrary",
  "bytes-lit",
@@ -1799,7 +1762,7 @@ dependencies = [
  "ctor",
  "derive_arbitrary",
  "ed25519-dalek",
- "rand 0.8.5",
+ "rand 0.8.7",
  "rustc_version",
  "serde",
  "serde_json",
@@ -1813,9 +1776,9 @@ dependencies = [
 
 [[package]]
 name = "soroban-sdk-macros"
-version = "27.0.2"
+version = "27.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3db611bd0acfe5fd348ffdcef16c84090c6ab051f3e325b5ac049a73044a7ee6"
+checksum = "2fe1f819f2cabfc5d24cd5ea4931403d1cd8a0f8cb2c8f12828034b7aa931163"
 dependencies = [
  "darling 0.20.11",
  "heck",
@@ -1833,9 +1796,9 @@ dependencies = [
 
 [[package]]
 name = "soroban-spec"
-version = "27.0.2"
+version = "27.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8061fe31998fe9fba8fcd7175b3e3ca914a6f6e3bf829fe91fdf7f930b1251d9"
+checksum = "f1340fc8ececace5546892ee6ce4d38555448b32fd0ce4b5f1fb0aa62aff93be"
 dependencies = [
  "base64",
  "sha2",
@@ -1846,9 +1809,9 @@ dependencies = [
 
 [[package]]
 name = "soroban-spec-rust"
-version = "27.0.2"
+version = "27.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2180cddacf3023a439827cb35c0e391ec413b1328173fe7c8c2743fc67b3af9e"
+checksum = "934be4593fbda64d7c08cfe2db0b0c34e00d9f00121821cc33ee6b3146be10c6"
 dependencies = [
  "prettyplease",
  "proc-macro2",
@@ -2010,9 +1973,9 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.54"
+version = "0.3.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e1d5e639ff6bab73cb6885cc7e7b1de96c3f32c68ec55f3952614bec1092244"
+checksum = "cdb87b95ec50ddfa440816d227a17b2ccbdda963a316a727fda0fc4334f7d134"
 dependencies = [
  "deranged",
  "num-conv",
@@ -2066,12 +2029,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94"
 
 [[package]]
-name = "unarray"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94"
-
-[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2082,6 +2039,17 @@ name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "visibility"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d674d135b4a8c1d7e813e2f8d1c9a58308aee4a680323066025e53132218bd91"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
 
 [[package]]
 name = "wait-timeout"
@@ -2265,18 +2233,18 @@ checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
 
 [[package]]
 name = "zerocopy"
-version = "0.8.55"
+version = "0.8.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5a105cd7b140f6eeec8acff2ea38135d3cab283ada58540f629fe51e46696eb"
+checksum = "556764e583adb45a9f8d413c2a147fa7e8d821e48e12b14fd560b607998b75eb"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.55"
+version = "0.8.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fe976fb70c78cd64cccfe3a6fc142244e8a77b70959b30faf9d0ac37ee228eb"
+checksum = "f2ab42fc20575779bd240faa45f94a74256f755c0fa9e89f0ede20d91d0cdfc1"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,21 @@ members = [
     "contracts/router",
     "contracts/flash_receiver_interface",
     "contracts/mock_flash_receiver",
+    "contracts/malicious_flash_receiver",
     "tests/fuzz"
+]
+# `tests/fuzz` requires `std` and is built/run only via its own explicit
+# `-p coralswap-fuzz` invocation (see the "Fuzz tests" CI step) — it isn't a
+# `no_std` wasm contract crate, so it must stay out of default-members or an
+# unscoped `cargo build --target wasm32*` across the workspace fails on it.
+default-members = [
+    "contracts/factory",
+    "contracts/pair",
+    "contracts/lp_token",
+    "contracts/router",
+    "contracts/flash_receiver_interface",
+    "contracts/mock_flash_receiver",
+    "contracts/malicious_flash_receiver",
 ]
 resolver = "2"
 

--- a/contracts/factory/src/lib.rs
+++ b/contracts/factory/src/lib.rs
@@ -173,12 +173,16 @@ impl Factory {
         let threshold = (storage.signers.len() + 1) / 2;
         governance::verify_multisig(&env, &signers, threshold)?;
 
-        // Find a signer in the call that matches a stored signer, then require its auth.
-        let authorized = signers
+        // Require that at least one of the (already auth-verified) provided
+        // signers is a registered signer. `verify_multisig` already called
+        // `require_auth()` on every provided signer above, so this is a
+        // membership check only — a second `require_auth()` on the same
+        // address here would be a redundant re-authorization within the same
+        // call frame, which soroban-sdk rejects.
+        signers
             .iter()
             .find(|s| storage.signers.contains(s))
             .ok_or(FactoryError::Unauthorized)?;
-        authorized.require_auth();
 
         storage.paused = true;
         storage::set_factory_storage(&env, &storage);
@@ -192,12 +196,12 @@ impl Factory {
         let threshold = (storage.signers.len() + 1) / 2;
         governance::verify_multisig(&env, &signers, threshold)?;
 
-        // Find a signer in the call that matches a stored signer, then require its auth.
-        let authorized = signers
+        // See the matching comment in `pause()` — membership check only,
+        // `verify_multisig` already required auth from every provided signer.
+        signers
             .iter()
             .find(|s| storage.signers.contains(s))
             .ok_or(FactoryError::Unauthorized)?;
-        authorized.require_auth();
 
         storage.paused = false;
         storage::set_factory_storage(&env, &storage);

--- a/contracts/factory/src/test/mod.rs
+++ b/contracts/factory/src/test/mod.rs
@@ -434,20 +434,20 @@ mod factory_tests {
 
     #[test]
     fn test_pause_authorized_signers_succeeds() {
-        let (env, client, _, _, _, _, _) = setup_env();
-        // setup_env initialises with 3 signers and mock_all_auths, so any
-        // address passes require_auth(). Threshold = ceil(3/2) = 2.
-        let s1 = Address::generate(&env);
-        let s2 = Address::generate(&env);
+        let (env, client, _, _, _, _, signers) = setup_env();
+        // setup_env registers 3 signers; pause() requires at least one of the
+        // provided signers to be a registered one. Threshold = ceil(3/2) = 2.
+        let s1 = signers.get(0).unwrap();
+        let s2 = signers.get(1).unwrap();
         client.pause(&Vec::from_array(&env, [s1, s2]));
         assert!(client.is_paused());
     }
 
     #[test]
     fn test_unpause_authorized_signers_succeeds() {
-        let (env, client, _, _, _, _, _) = setup_env();
-        let s1 = Address::generate(&env);
-        let s2 = Address::generate(&env);
+        let (env, client, _, _, _, _, signers) = setup_env();
+        let s1 = signers.get(0).unwrap();
+        let s2 = signers.get(1).unwrap();
         client.pause(&Vec::from_array(&env, [s1.clone(), s2.clone()]));
         client.unpause(&Vec::from_array(&env, [s1, s2]));
         assert!(!client.is_paused());
@@ -760,6 +760,6 @@ mod factory_tests {
         client.set_pair_fee(&fee_to_setter, &pair, &5u32);
 
         let all = env.events().all();
-        assert_eq!(all.len(), 1, "set_pair_fee must emit exactly one event on success");
+        assert_eq!(all.events().len(), 1, "set_pair_fee must emit exactly one event on success");
     }
 }

--- a/contracts/malicious_flash_receiver/Cargo.toml
+++ b/contracts/malicious_flash_receiver/Cargo.toml
@@ -1,10 +1,10 @@
 [package]
-name = "coralswap-mock-flash-receiver"
+name = "coralswap-malicious-flash-receiver"
 version = "0.1.0"
 edition = "2021"
 
 [lib]
-crate-type = ["cdylib", "rlib"]
+crate-type = ["rlib"]
 
 [dependencies]
 soroban-sdk = { workspace = true }

--- a/contracts/malicious_flash_receiver/src/lib.rs
+++ b/contracts/malicious_flash_receiver/src/lib.rs
@@ -9,6 +9,12 @@ use soroban_sdk::{contract, contractimpl, Address, Bytes, Env};
 /// `data` selects the attack vector:
 /// - `b"attack_swap"` — re-enter the pair via `swap()` during the callback
 /// - `b"attack_flash"` — nest another `flash_loan()` during the callback
+///
+/// Only ever registered natively (`env.register_contract`) in unit tests,
+/// never deployed as a real wasm contract — this crate has no `cdylib`
+/// target, so it can't collide with `MockFlashReceiver`'s exported
+/// `on_flash_loan` symbol at the wasm level even if both ended up in the
+/// same build graph.
 #[contract]
 pub struct MaliciousFlashReceiver;
 

--- a/contracts/mock_flash_receiver/src/lib.rs
+++ b/contracts/mock_flash_receiver/src/lib.rs
@@ -1,7 +1,5 @@
 #![no_std]
 
-pub mod malicious;
-
 use coralswap_flash_receiver_interface::FlashReceiver;
 use soroban_sdk::{contract, contractimpl, token::TokenClient, Address, Bytes, Env};
 

--- a/contracts/pair/Cargo.toml
+++ b/contracts/pair/Cargo.toml
@@ -16,3 +16,4 @@ ethnum = { version = "*" }
 soroban-sdk = { workspace = true, features = ["testutils"] }
 coralswap-lp-token = { path = "../lp_token" }
 coralswap-mock-flash-receiver = { path = "../mock_flash_receiver" }
+coralswap-malicious-flash-receiver = { path = "../malicious_flash_receiver" }

--- a/contracts/pair/src/events.rs
+++ b/contracts/pair/src/events.rs
@@ -113,14 +113,14 @@ impl PairEvents {
     /// Emits a `stale_threshold_updated` event when the EMA staleness decay
     /// threshold is reconfigured.
     ///
-    /// Topics: `("stl_thresh",)`
+    /// Topics: `("stl_thrsh",)`
     /// Data:   `(new_threshold,)`
     ///
     /// Called by `Pair::set_stale_threshold()` after a successful threshold update.
     /// "stale_threshold_updated" is too long for symbol_short!, so we use
-    /// "stl_thresh" (9 chars).
+    /// "stl_thrsh" (9 chars).
     pub fn stale_threshold_updated(env: &Env, new_threshold: u32) {
-        env.events().publish((symbol_short!("stl_thresh"),), (new_threshold,));
+        env.events().publish((symbol_short!("stl_thrsh"),), (new_threshold,));
     }
 
     #[allow(dead_code)]

--- a/contracts/pair/src/fee_decay.rs
+++ b/contracts/pair/src/fee_decay.rs
@@ -38,6 +38,13 @@ pub fn apply_time_decay(_env: &Env, fee_state: &mut FeeState, current_ledger: u6
     let threshold = fee_state.decay_threshold_blocks.max(1);
     let decay_periods = (elapsed / threshold).min(MAX_DECAY_PERIODS);
 
+    // Not enough elapsed time to complete even one decay period — leave
+    // last_fee_update untouched so the unconsumed elapsed time keeps
+    // accumulating toward the next call instead of being silently reset.
+    if decay_periods == 0 {
+        return;
+    }
+
     // Apply compounding exponential decay: vol /= divisor per period.
     for _ in 0..decay_periods {
         fee_state.vol_accumulator /= divisor;

--- a/contracts/pair/src/test/dynamic_fee.rs
+++ b/contracts/pair/src/test/dynamic_fee.rs
@@ -857,6 +857,11 @@ fn test_stale_threshold_boundary_1() {
     fee_state.vol_accumulator = 1_000_000_000_000;
     fee_state.last_fee_update = 0;
     fee_state.stale_threshold = 1; // Minimum valid threshold
+    // Isolate the stale_threshold gate from decay_threshold_blocks (a
+    // separate field governing how many decay periods elapsed time buys) —
+    // without this, decay_periods = elapsed / decay_threshold_blocks = 2/100
+    // rounds down to 0, so the gate fires but no decay is visible.
+    fee_state.decay_threshold_blocks = 1;
 
     let initial_vol = fee_state.vol_accumulator;
 

--- a/contracts/pair/src/test/events.rs
+++ b/contracts/pair/src/test/events.rs
@@ -35,7 +35,7 @@ fn swap_event_emits_correct_topics_and_data() {
     });
 
     let all = env.events().all();
-    assert_eq!(all.len(), 1, "expected exactly one swap event");
+    assert_eq!(all.events().len(), 1, "expected exactly one swap event");
 }
 
 // ---------------------------------------------------------------------------
@@ -52,7 +52,7 @@ fn mint_event_emits_correct_topics_and_data() {
     });
 
     let all = env.events().all();
-    assert_eq!(all.len(), 1, "expected exactly one mint event");
+    assert_eq!(all.events().len(), 1, "expected exactly one mint event");
 }
 
 // ---------------------------------------------------------------------------
@@ -70,7 +70,7 @@ fn burn_event_emits_correct_topics_and_data() {
     });
 
     let all = env.events().all();
-    assert_eq!(all.len(), 1, "expected exactly one burn event");
+    assert_eq!(all.events().len(), 1, "expected exactly one burn event");
 }
 
 // ---------------------------------------------------------------------------
@@ -86,7 +86,7 @@ fn sync_event_emits_correct_topics_and_data() {
     });
 
     let all = env.events().all();
-    assert_eq!(all.len(), 1, "expected exactly one sync event");
+    assert_eq!(all.events().len(), 1, "expected exactly one sync event");
 }
 
 // ---------------------------------------------------------------------------
@@ -103,7 +103,7 @@ fn reward_added_event_emits_correct_topics_and_data() {
     });
 
     let all = env.events().all();
-    assert_eq!(all.len(), 1, "expected exactly one reward_added event");
+    assert_eq!(all.events().len(), 1, "expected exactly one reward_added event");
 }
 
 // ---------------------------------------------------------------------------
@@ -120,7 +120,7 @@ fn reward_rate_event_emits_correct_topics_and_data() {
     });
 
     let all = env.events().all();
-    assert_eq!(all.len(), 1, "expected exactly one reward_rate event");
+    assert_eq!(all.events().len(), 1, "expected exactly one reward_rate event");
 }
 
 // ---------------------------------------------------------------------------
@@ -138,7 +138,7 @@ fn rewards_claimed_event_emits_correct_topics_and_data() {
     });
 
     let all = env.events().all();
-    assert_eq!(all.len(), 1, "expected exactly one rewards_claimed event");
+    assert_eq!(all.events().len(), 1, "expected exactly one rewards_claimed event");
 }
 
 // ---------------------------------------------------------------------------
@@ -155,7 +155,7 @@ fn flash_loan_event_emits_correct_topics_and_data() {
     });
 
     let all = env.events().all();
-    assert_eq!(all.len(), 1, "expected exactly one flash_loan event");
+    assert_eq!(all.events().len(), 1, "expected exactly one flash_loan event");
 }
 
 // ---------------------------------------------------------------------------
@@ -173,5 +173,5 @@ fn multiple_events_are_independent() {
     });
 
     let all = env.events().all();
-    assert_eq!(all.len(), 2, "expected two events in order");
+    assert_eq!(all.events().len(), 2, "expected two events in order");
 }

--- a/contracts/pair/src/test/flash_loan.rs
+++ b/contracts/pair/src/test/flash_loan.rs
@@ -1,6 +1,7 @@
 #![cfg(test)]
 
-use coralswap_mock_flash_receiver::{malicious::MaliciousFlashReceiver, MockFlashReceiver};
+use coralswap_malicious_flash_receiver::MaliciousFlashReceiver;
+use coralswap_mock_flash_receiver::MockFlashReceiver;
 
 use crate::{errors::PairError, Pair, PairClient};
 use soroban_sdk::token::{StellarAssetClient, TokenClient};

--- a/contracts/pair/src/test/set_stale_threshold.rs
+++ b/contracts/pair/src/test/set_stale_threshold.rs
@@ -1,7 +1,7 @@
 use crate::errors::PairError;
 use crate::{Pair, PairClient};
 use coralswap_lp_token::{LpToken, LpTokenClient};
-use soroban_sdk::{testutils::Address as _, Address, Env, String};
+use soroban_sdk::{testutils::Address as _, testutils::Ledger as _, Address, Env, String};
 
 /// Helper to deploy and initialize pair for testing
 fn setup_pair(env: &Env) -> (PairClient<'static>, Address, Address, Address, Address) {
@@ -72,7 +72,7 @@ fn test_set_stale_threshold_validation_zero_fails() {
 
     assert!(result.is_err());
     if let Err(e) = result {
-        assert_eq!(e, PairError::InvalidStaleThreshold);
+        assert_eq!(e, Ok(PairError::InvalidStaleThreshold));
     }
 }
 
@@ -88,7 +88,7 @@ fn test_set_stale_threshold_validation_exceeds_max() {
 
     assert!(result.is_err());
     if let Err(e) = result {
-        assert_eq!(e, PairError::InvalidStaleThreshold);
+        assert_eq!(e, Ok(PairError::InvalidStaleThreshold));
     }
 }
 
@@ -218,7 +218,7 @@ fn test_set_stale_threshold_invalid_values() {
         let result = pair_client.try_set_stale_threshold(&threshold);
         assert!(result.is_err(), "Should reject invalid threshold: {}", threshold);
         if let Err(e) = result {
-            assert_eq!(e, PairError::InvalidStaleThreshold);
+            assert_eq!(e, Ok(PairError::InvalidStaleThreshold));
         }
     }
 }

--- a/contracts/pair/src/test/views.rs
+++ b/contracts/pair/src/test/views.rs
@@ -1,5 +1,6 @@
 #![cfg(test)]
 
+use crate::dynamic_fee::DEFAULT_STALE_LEDGER_THRESHOLD;
 use crate::storage::{FeeState, PairStorage};
 use crate::{Pair, PairClient};
 use soroban_sdk::{testutils::Address as _, testutils::Ledger, Address, Env};
@@ -137,6 +138,7 @@ fn test_get_current_fee_bps_with_state() {
         cooldown_divisor: 2,
         last_fee_update: 0,
         decay_threshold_blocks: 100,
+        stale_threshold: DEFAULT_STALE_LEDGER_THRESHOLD,
     };
 
     env.as_contract(&contract_id, || {

--- a/scripts/benchmark.sh
+++ b/scripts/benchmark.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+# Measures the compiled wasm size of each deployable contract and writes the
+# result to benchmark-results.json, consumed by the "Contract Size Benchmark"
+# CI workflow (.github/workflows/benchmark.yml) to flag size regressions on
+# PRs. Contract size directly affects deployment cost and the per-invocation
+# resource budget on Soroban, so this is tracked the same way build/test are.
+
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+WASM_TARGET="wasm32v1-none"
+OUTPUT_FILE="benchmark-results.json"
+
+# contract short-name -> crate directory
+declare -A CONTRACTS=(
+  [factory]="factory"
+  [lp_token]="lp_token"
+  [pair]="pair"
+  [router]="router"
+)
+
+echo "Building contracts for --target $WASM_TARGET (release)..."
+cargo build --release --target "$WASM_TARGET" \
+  -p coralswap-factory \
+  -p coralswap-lp-token \
+  -p coralswap-pair \
+  -p coralswap-router
+
+WASM_DIR="target/$WASM_TARGET/release"
+
+result="{}"
+for name in "${!CONTRACTS[@]}"; do
+  crate_dir="${CONTRACTS[$name]}"
+  crate_name=$(grep -m1 '^name' "contracts/$crate_dir/Cargo.toml" | sed -E 's/^name = "(.*)"$/\1/')
+  wasm_file="$WASM_DIR/${crate_name//-/_}.wasm"
+
+  if [ ! -f "$wasm_file" ]; then
+    echo "error: expected wasm artifact not found: $wasm_file" >&2
+    exit 1
+  fi
+
+  size_bytes=$(stat -c%s "$wasm_file" 2>/dev/null || stat -f%z "$wasm_file")
+  echo "  $name: $size_bytes bytes ($wasm_file)"
+  result=$(echo "$result" | jq --arg name "$name" --argjson size "$size_bytes" \
+    '.contracts[$name] = {size_bytes: $size}')
+done
+
+echo "$result" | jq '.' > "$OUTPUT_FILE"
+echo "Wrote $OUTPUT_FILE"


### PR DESCRIPTION
## Summary

`main` currently fails CI at multiple stages, both from a corrupted `Cargo.lock` and from a wasm build-target incompatibility with modern soroban-sdk. This fixes the full chain of issues underneath, plus two real contract-logic bugs the fix uncovered.

**1. `Cargo.lock` corruption** — `fastrand` was duplicated (identical block twice) and several other entries had checksums/dependencies copy-pasted from unrelated packages (e.g. `gimli` carried `getrandom`'s checksum), breaking `cargo`'s lockfile parser outright. Regenerated cleanly via `cargo generate-lockfile`.

**2. wasm target incompatibility** — soroban-sdk 26.x and 27.x reject `wasm32-unknown-unknown` on Rust 1.82+ (the target gained default-enabled features their WASM VM doesn't yet support) and require `wasm32v1-none` instead. Verified empirically per SDK version: 21.7.7 builds fine on the old target, 26.1.0 and 27.x both need the new one. Updated `matrix.yml` to use the correct target per matrix leg, and `ci.yml`/`benchmark.yml` (which build against `Cargo.toml`'s default `27.0.2` pin) to use `wasm32v1-none` unconditionally.

**3. `symbol_short!("stl_thresh")` — 10 characters, over Soroban's 9-char limit.** Renamed to `stl_thrsh`.

**4. `ContractEvents::all().len()` — soroban-sdk 27.x API change.** `Events::all()` now returns a `ContractEvents` struct with no `.len()`; the raw event slice is behind `.events()`. Fixed 11 call sites in `pair`'s and `factory`'s event-emission tests.

**5. `MaliciousFlashReceiver` / `MockFlashReceiver` wasm symbol collision.** Both contract types lived in one crate; Soroban's `#[contractimpl]` exports contract methods as top-level wasm symbols, not namespaced per struct, so their two `on_flash_loan` implementations collided when the crate compiled as a single `cdylib`. `MaliciousFlashReceiver` is only ever used via native `register_contract()` in reentrancy tests — never deployed as real wasm — so it's moved into its own crate with no `cdylib` target, closing the bug class structurally rather than working around today's symptom.

**6. Workspace `default-members`.** `tests/fuzz` needs `std` and was never meant to be part of a blanket wasm build (it has its own dedicated `-p coralswap-fuzz --features fuzz` CI step) — an unscoped `cargo build --target wasm32*` across the whole workspace was failing on it. Added `default-members` excluding it.

**7. `scripts/benchmark.sh` didn't exist.** The "Contract Size Benchmark" workflow has been calling a script that was never committed, likely because `.gitignore` had a blanket `*.sh` rule silently swallowing every shell script in the repo (this also explains why `scripts/deploy.sh`, documented in `scripts/README.md`, is missing too — flagging that one separately, out of scope here). Removed the `*.sh` rule and wrote `benchmark.sh` to the exact contract the workflow already expects (`.contracts.<name>.size_bytes` in `benchmark-results.json`).

**8. Factory governance: real double-authorization bug.** `pause()`/`unpause()` called `.require_auth()` on a signer that `verify_multisig()` had already required auth from moments earlier in the same call — soroban-sdk 27.x's stricter auth-frame tracking now correctly rejects this as `Error(Auth, ExistingValue)` ("frame is already authorized"). Removed the redundant second call; the membership check (verifying at least one provided signer is a registered one) stays, `verify_multisig`'s per-signer auth loop already covers authorization.

**9. `apply_time_decay` — real decay-accounting bug.** `last_fee_update` was unconditionally bumped to `current_ledger` even when zero actual decay periods had elapsed (`elapsed / decay_threshold_blocks == 0`). For a pool with regular activity at intervals shorter than `decay_threshold_blocks`, this would perpetually reset the elapsed-time baseline before it could ever accumulate to a real decay period — decay would never fire in practice. Now only updates `last_fee_update` when at least one decay period actually applied.

**10. Two test bugs** in `factory`'s pause/unpause tests (used freshly-generated addresses instead of the actual registered signers from `setup_env()`) and one in `pair`'s `dynamic_fee` tests (conflated the `stale_threshold` gate with the separate `decay_threshold_blocks` amount, so the assertion couldn't observe real decay at the ledger counts used).

Also removed a dead `[target.wasm32-unknown-unknown] rustflags` workaround in `mock_flash_receiver/Cargo.toml` — an earlier partial attempt at fixing #2 for just that one crate, superseded by the real target migration.

## Testing

- `cargo build --release --target wasm32v1-none` (full workspace): clean
- `cargo test --workspace`: clean, 3 consecutive runs with no flakiness
- `cargo test -p coralswap-fuzz --features fuzz`: clean
- `./scripts/benchmark.sh`: runs end-to-end, output verified against `benchmark.yml`'s exact `jq` query shape
- `cargo fmt --all -- --check`: pre-existing findings outside this diff untouched, left as-is (verified via hunk-range cross-reference against `git diff`)
- Verified per-SDK-version wasm target requirement empirically (21.7.7 vs 26.1.0/27.x) before writing the matrix.yml conditional, not guessed